### PR TITLE
optimize mload instruction to not allocate a temporary vector

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ before are not supported.
 
 ## Build from sources
 
-SputnikVM is written Rust. If you are not familiar with Rust please
+SputnikVM is written in Rust. If you are not familiar with Rust please
 see the
 [getting started guide](https://doc.rust-lang.org/book/getting-started.html).
 

--- a/core/src/eval/misc.rs
+++ b/core/src/eval/misc.rs
@@ -81,7 +81,7 @@ pub fn mload(state: &mut Machine) -> Control {
 	pop_u256!(state, index);
 	try_or_fail!(state.memory.resize_offset(index, U256::from(32)));
 	let index = as_usize_or_fail!(index);
-	let value = H256::from_slice(&state.memory.get(index, 32)[..]);
+	let value = state.memory.get_h256(index);
 	push!(state, value);
 	Control::Continue(1)
 }

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -2,7 +2,7 @@ use crate::{ExitError, ExitFatal};
 use alloc::vec::Vec;
 use core::cmp::min;
 use core::ops::{BitAnd, Not};
-use primitive_types::{U256, H256};
+use primitive_types::{H256, U256};
 
 /// A sequencial memory. It uses Rust's `Vec` for internal
 /// representation.

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -2,7 +2,7 @@ use crate::{ExitError, ExitFatal};
 use alloc::vec::Vec;
 use core::cmp::min;
 use core::ops::{BitAnd, Not};
-use primitive_types::U256;
+use primitive_types::{U256, H256};
 
 /// A sequencial memory. It uses Rust's `Vec` for internal
 /// representation.
@@ -94,6 +94,23 @@ impl Memory {
 		}
 
 		ret
+	}
+
+	/// Get `H256` from a specific offset in memory.
+	pub fn get_h256(&self, offset: usize) -> H256 {
+		let mut ret = [0; 32];
+
+		#[allow(clippy::needless_range_loop)]
+		for index in 0..32 {
+			let position = offset + index;
+			if position >= self.data.len() {
+				break;
+			}
+
+			ret[index] = self.data[position];
+		}
+
+		H256(ret)
 	}
 
 	/// Set memory region at given offset. The offset and value is considered

--- a/gasometer/src/costs.rs
+++ b/gasometer/src/costs.rs
@@ -206,29 +206,33 @@ pub fn sstore_cost(
 	is_cold: bool,
 	config: &Config,
 ) -> Result<u64, ExitError> {
-	let gas_cost = if config.sstore_gas_metering {
-		if config.sstore_revert_under_stipend && gas <= config.call_stipend {
-			return Err(ExitError::OutOfGas);
-		}
-
-		if new == current {
-			config.gas_sload
-		} else {
-			if original == current {
-				if original == H256::zero() {
-					config.gas_sstore_set
-				} else {
-					config.gas_sstore_reset
-				}
-			} else {
-				config.gas_sload
-			}
-		}
+	let gas_cost = if config.estimate {
+		config.gas_sstore_set
 	} else {
-		if current == H256::zero() && new != H256::zero() {
-			config.gas_sstore_set
+		if config.sstore_gas_metering {
+			if config.sstore_revert_under_stipend && gas <= config.call_stipend {
+				return Err(ExitError::OutOfGas);
+			}
+
+			if new == current {
+				config.gas_sload
+			} else {
+				if original == current {
+					if original == H256::zero() {
+						config.gas_sstore_set
+					} else {
+						config.gas_sstore_reset
+					}
+				} else {
+					config.gas_sload
+				}
+			}
 		} else {
-			config.gas_sstore_reset
+			if current == H256::zero() && new != H256::zero() {
+				config.gas_sstore_set
+			} else {
+				config.gas_sstore_reset
+			}
 		}
 	};
 	Ok(

--- a/gasometer/src/lib.rs
+++ b/gasometer/src/lib.rs
@@ -782,7 +782,6 @@ impl<'config> Inner<'config> {
 				target_exists,
 				..
 			} => costs::suicide_cost(value, target_is_cold, target_exists, self.config),
-			GasCost::SStore { .. } if self.config.estimate => self.config.gas_sstore_set,
 			GasCost::SStore {
 				original,
 				current,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.51.0"
+channel = "1.58.1"
 profile = "minimal"
 components = [ "rustfmt", "clippy" ]

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -396,7 +396,7 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 		init_code: Vec<u8>,
 		gas_limit: u64,
 		access_list: Vec<(H160, Vec<H256>)>, // See EIP-2930
-	) -> ExitReason {
+	) -> (ExitReason, Vec<u8>) {
 		event!(TransactCreate {
 			caller,
 			value,
@@ -406,7 +406,7 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 		});
 
 		if let Err(e) = self.record_create_transaction_cost(&init_code, &access_list) {
-			return emit_exit!(e.into());
+			return emit_exit!(e.into(), Vec::new());
 		}
 		self.initialize_with_access_list(access_list);
 
@@ -418,7 +418,7 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 			Some(gas_limit),
 			false,
 		) {
-			Capture::Exit((s, _, _)) => emit_exit!(s),
+			Capture::Exit((s, _, v)) => emit_exit!(s, v),
 			Capture::Trap(_) => unreachable!(),
 		}
 	}
@@ -432,7 +432,7 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 		salt: H256,
 		gas_limit: u64,
 		access_list: Vec<(H160, Vec<H256>)>, // See EIP-2930
-	) -> ExitReason {
+	) -> (ExitReason, Vec<u8>) {
 		let code_hash = H256::from_slice(Keccak256::digest(&init_code).as_slice());
 		event!(TransactCreate2 {
 			caller,
@@ -448,7 +448,7 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 		});
 
 		if let Err(e) = self.record_create_transaction_cost(&init_code, &access_list) {
-			return emit_exit!(e.into());
+			return emit_exit!(e.into(), Vec::new());
 		}
 		self.initialize_with_access_list(access_list);
 
@@ -464,7 +464,7 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 			Some(gas_limit),
 			false,
 		) {
-			Capture::Exit((s, _, _)) => emit_exit!(s),
+			Capture::Exit((s, _, v)) => emit_exit!(s, v),
 			Capture::Trap(_) => unreachable!(),
 		}
 	}

--- a/src/executor/stack/memory.rs
+++ b/src/executor/stack/memory.rs
@@ -555,6 +555,11 @@ impl<'backend, 'config, B: Backend> MemoryStackState<'backend, 'config, B> {
 		}
 	}
 
+	/// Returns a mutable reference to an account given its address
+	pub fn account_mut(&mut self, address: H160) -> &mut MemoryStackAccount {
+		self.substate.account_mut(address, self.backend)
+	}
+
 	#[must_use]
 	pub fn deconstruct(
 		self,


### PR DESCRIPTION
Naked-eye based optimization -- it feels suboptimal to allocate a `Vec`
to fetch `[0; u32]`. Running uniswap bench in aurora shows that this is
an 1% improvement in wasm cost, so the compiler probably can't eliminate
this vec entirely.