### PR TITLE
switch vm stack to little endian representation 

### DIFF
--- a/core/src/eval/macros.rs
+++ b/core/src/eval/macros.rs
@@ -7,11 +7,15 @@ macro_rules! try_or_fail {
 	};
 }
 
-macro_rules! pop {
+macro_rules! pop_h256 {
 	( $machine:expr, $( $x:ident ),* ) => (
 		$(
 			let $x = match $machine.stack.pop() {
-				Ok(value) => value,
+				Ok(value) => {
+					let mut res = H256([0; 32]);
+					value.to_big_endian(&mut res[..]);
+					res
+				},
 				Err(e) => return Control::Exit(e.into()),
 			};
 		)*
@@ -22,17 +26,17 @@ macro_rules! pop_u256 {
 	( $machine:expr, $( $x:ident ),* ) => (
 		$(
 			let $x = match $machine.stack.pop() {
-				Ok(value) => U256::from_big_endian(&value[..]),
+				Ok(value) => value,
 				Err(e) => return Control::Exit(e.into()),
 			};
 		)*
 	);
 }
 
-macro_rules! push {
+macro_rules! push_h256 {
 	( $machine:expr, $( $x:expr ),* ) => (
 		$(
-			match $machine.stack.push($x) {
+			match $machine.stack.push(U256::from_big_endian(&$x[..])) {
 				Ok(()) => (),
 				Err(e) => return Control::Exit(e.into()),
 			}
@@ -43,9 +47,7 @@ macro_rules! push {
 macro_rules! push_u256 {
 	( $machine:expr, $( $x:expr ),* ) => (
 		$(
-			let mut value = H256::default();
-			$x.to_big_endian(&mut value[..]);
-			match $machine.stack.push(value) {
+			match $machine.stack.push($x) {
 				Ok(()) => (),
 				Err(e) => return Control::Exit(e.into()),
 			}

--- a/core/src/eval/misc.rs
+++ b/core/src/eval/misc.rs
@@ -41,7 +41,7 @@ pub fn calldataload(state: &mut Machine) -> Control {
 		}
 	}
 
-	push!(state, H256::from(load));
+	push_h256!(state, H256::from(load));
 	Control::Continue(1)
 }
 
@@ -72,7 +72,7 @@ pub fn calldatacopy(state: &mut Machine) -> Control {
 
 #[inline]
 pub fn pop(state: &mut Machine) -> Control {
-	pop!(state, _val);
+	pop_u256!(state, _val);
 	Control::Continue(1)
 }
 
@@ -82,14 +82,14 @@ pub fn mload(state: &mut Machine) -> Control {
 	try_or_fail!(state.memory.resize_offset(index, U256::from(32)));
 	let index = as_usize_or_fail!(index);
 	let value = state.memory.get_h256(index);
-	push!(state, value);
+	push_h256!(state, value);
 	Control::Continue(1)
 }
 
 #[inline]
 pub fn mstore(state: &mut Machine) -> Control {
 	pop_u256!(state, index);
-	pop!(state, value);
+	pop_h256!(state, value);
 	try_or_fail!(state.memory.resize_offset(index, U256::from(32)));
 	let index = as_usize_or_fail!(index);
 	match state.memory.set(index, &value[..], Some(32)) {
@@ -125,7 +125,7 @@ pub fn jump(state: &mut Machine) -> Control {
 #[inline]
 pub fn jumpi(state: &mut Machine) -> Control {
 	pop_u256!(state, dest);
-	pop!(state, value);
+	pop_h256!(state, value);
 
 	if value != H256::zero() {
 		let dest = as_usize_or_fail!(dest, ExitError::InvalidJump);
@@ -155,10 +155,9 @@ pub fn msize(state: &mut Machine) -> Control {
 pub fn push(state: &mut Machine, n: usize, position: usize) -> Control {
 	let end = min(position + 1 + n, state.code.len());
 	let slice = &state.code[(position + 1)..end];
-	let mut val = [0u8; 32];
-	val[(32 - slice.len())..32].copy_from_slice(slice);
+	let val = U256::from_big_endian(slice);
 
-	push!(state, H256(val));
+	push_u256!(state, val);
 	Control::Continue(1 + n)
 }
 
@@ -168,7 +167,7 @@ pub fn dup(state: &mut Machine, n: usize) -> Control {
 		Ok(value) => value,
 		Err(e) => return Control::Exit(e.into()),
 	};
-	push!(state, value);
+	push_u256!(state, value);
 	Control::Continue(1)
 }
 

--- a/core/src/eval/misc.rs
+++ b/core/src/eval/misc.rs
@@ -81,7 +81,7 @@ pub fn mload(state: &mut Machine) -> Control {
 	pop_u256!(state, index);
 	try_or_fail!(state.memory.resize_offset(index, U256::from(32)));
 	let index = as_usize_or_fail!(index);
-	let value = H256::from_slice(&state.memory.get(index, 32)[..]);
+	let value = state.memory.get_h256(index);
 	push!(state, value);
 	Control::Continue(1)
 }

--- a/core/src/eval/misc.rs
+++ b/core/src/eval/misc.rs
@@ -125,9 +125,9 @@ pub fn jump(state: &mut Machine) -> Control {
 #[inline]
 pub fn jumpi(state: &mut Machine) -> Control {
 	pop_u256!(state, dest);
-	pop_h256!(state, value);
+	pop_u256!(state, value);
 
-	if value != H256::zero() {
+	if value != U256::zero() {
 		let dest = as_usize_or_fail!(dest, ExitError::InvalidJump);
 		if state.valids.is_valid(dest) {
 			Control::Jump(dest)

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -6,7 +6,7 @@ mod misc;
 
 use crate::{ExitError, ExitReason, ExitSucceed, Machine, Opcode};
 use core::ops::{BitAnd, BitOr, BitXor};
-use primitive_types::{H256, U256};
+use primitive_types::U256;
 
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub enum Control {

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -2,7 +2,7 @@ use crate::{ExitError, ExitFatal};
 use alloc::vec::Vec;
 use core::cmp::min;
 use core::ops::{BitAnd, Not};
-use primitive_types::{U256, H256};
+use primitive_types::{H256, U256};
 
 /// A sequencial memory. It uses Rust's `Vec` for internal
 /// representation.

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -2,7 +2,7 @@ use crate::{ExitError, ExitFatal};
 use alloc::vec::Vec;
 use core::cmp::min;
 use core::ops::{BitAnd, Not};
-use primitive_types::U256;
+use primitive_types::{U256, H256};
 
 /// A sequencial memory. It uses Rust's `Vec` for internal
 /// representation.
@@ -94,6 +94,23 @@ impl Memory {
 		}
 
 		ret
+	}
+
+	/// Get `H256` from a specific offset in memory.
+	pub fn get_h256(&self, offset: usize) -> H256 {
+		let mut ret = [0; 32];
+
+		#[allow(clippy::needless_range_loop)]
+		for index in 0..32 {
+			let position = offset + index;
+			if position >= self.data.len() {
+				break;
+			}
+
+			ret[index] = self.data[position];
+		}
+
+		H256(ret)
 	}
 
 	/// Set memory region at given offset. The offset and value is considered

--- a/core/src/stack.rs
+++ b/core/src/stack.rs
@@ -1,11 +1,11 @@
 use crate::ExitError;
 use alloc::vec::Vec;
-use primitive_types::H256;
+use primitive_types::{H256, U256};
 
 /// EVM stack.
 #[derive(Clone, Debug)]
 pub struct Stack {
-	data: Vec<H256>,
+	data: Vec<U256>,
 	limit: usize,
 }
 
@@ -38,21 +38,30 @@ impl Stack {
 
 	#[inline]
 	/// Stack data.
-	pub fn data(&self) -> &Vec<H256> {
+	pub fn data(&self) -> &Vec<U256> {
 		&self.data
 	}
 
 	#[inline]
 	/// Pop a value from the stack. If the stack is already empty, returns the
 	/// `StackUnderflow` error.
-	pub fn pop(&mut self) -> Result<H256, ExitError> {
+	pub fn pop(&mut self) -> Result<U256, ExitError> {
 		self.data.pop().ok_or(ExitError::StackUnderflow)
+	}
+
+	#[inline]
+	pub fn pop_h256(&mut self) -> Result<H256, ExitError> {
+		self.pop().map(|it| {
+			let mut res = H256([0; 32]);
+			it.to_big_endian(&mut res.0);
+			res
+		})
 	}
 
 	#[inline]
 	/// Push a new value into the stack. If it will exceed the stack limit,
 	/// returns `StackOverflow` error and leaves the stack unchanged.
-	pub fn push(&mut self, value: H256) -> Result<(), ExitError> {
+	pub fn push(&mut self, value: U256) -> Result<(), ExitError> {
 		if self.data.len() + 1 > self.limit {
 			return Err(ExitError::StackOverflow);
 		}
@@ -64,7 +73,7 @@ impl Stack {
 	/// Peek a value at given index for the stack, where the top of
 	/// the stack is at index `0`. If the index is too large,
 	/// `StackError::Underflow` is returned.
-	pub fn peek(&self, no_from_top: usize) -> Result<H256, ExitError> {
+	pub fn peek(&self, no_from_top: usize) -> Result<U256, ExitError> {
 		if self.data.len() > no_from_top {
 			Ok(self.data[self.data.len() - no_from_top - 1])
 		} else {
@@ -73,10 +82,22 @@ impl Stack {
 	}
 
 	#[inline]
+	/// Peek a value at given index for the stack, where the top of
+	/// the stack is at index `0`. If the index is too large,
+	/// `StackError::Underflow` is returned.
+	pub fn peek_h256(&self, no_from_top: usize) -> Result<H256, ExitError> {
+		self.peek(no_from_top).map(|it| {
+			let mut res = H256([0; 32]);
+			it.to_big_endian(&mut res.0);
+			res
+		})
+	}
+
+	#[inline]
 	/// Set a value at given index for the stack, where the top of the
 	/// stack is at index `0`. If the index is too large,
 	/// `StackError::Underflow` is returned.
-	pub fn set(&mut self, no_from_top: usize, val: H256) -> Result<(), ExitError> {
+	pub fn set(&mut self, no_from_top: usize, val: U256) -> Result<(), ExitError> {
 		if self.data.len() > no_from_top {
 			let len = self.data.len();
 			self.data[len - no_from_top - 1] = val;

--- a/gasometer/src/lib.rs
+++ b/gasometer/src/lib.rs
@@ -465,14 +465,14 @@ pub fn dynamic_opcode_cost<H: Handler>(
 		Opcode::BASEFEE => GasCost::Invalid,
 
 		Opcode::EXTCODESIZE => {
-			let target = stack.peek(0)?.into();
+			let target = stack.peek_h256(0)?.into();
 			storage_target = StorageTarget::Address(target);
 			GasCost::ExtCodeSize {
 				target_is_cold: handler.is_cold(target, None),
 			}
 		}
 		Opcode::BALANCE => {
-			let target = stack.peek(0)?.into();
+			let target = stack.peek_h256(0)?.into();
 			storage_target = StorageTarget::Address(target);
 			GasCost::Balance {
 				target_is_cold: handler.is_cold(target, None),
@@ -481,7 +481,7 @@ pub fn dynamic_opcode_cost<H: Handler>(
 		Opcode::BLOCKHASH => GasCost::BlockHash,
 
 		Opcode::EXTCODEHASH if config.has_ext_code_hash => {
-			let target = stack.peek(0)?.into();
+			let target = stack.peek_h256(0)?.into();
 			storage_target = StorageTarget::Address(target);
 			GasCost::ExtCodeHash {
 				target_is_cold: handler.is_cold(target, None),
@@ -490,43 +490,43 @@ pub fn dynamic_opcode_cost<H: Handler>(
 		Opcode::EXTCODEHASH => GasCost::Invalid,
 
 		Opcode::CALLCODE => {
-			let target = stack.peek(1)?.into();
+			let target = stack.peek_h256(1)?.into();
 			storage_target = StorageTarget::Address(target);
 			GasCost::CallCode {
-				value: U256::from_big_endian(&stack.peek(2)?[..]),
-				gas: U256::from_big_endian(&stack.peek(0)?[..]),
+				value: stack.peek(2)?,
+				gas: stack.peek(0)?,
 				target_is_cold: handler.is_cold(target, None),
 				target_exists: handler.exists(target),
 			}
 		}
 		Opcode::STATICCALL => {
-			let target = stack.peek(1)?.into();
+			let target = stack.peek_h256(1)?.into();
 			storage_target = StorageTarget::Address(target);
 			GasCost::StaticCall {
-				gas: U256::from_big_endian(&stack.peek(0)?[..]),
+				gas: stack.peek(0)?,
 				target_is_cold: handler.is_cold(target, None),
 				target_exists: handler.exists(target),
 			}
 		}
 		Opcode::SHA3 => GasCost::Sha3 {
-			len: U256::from_big_endian(&stack.peek(1)?[..]),
+			len: stack.peek(1)?,
 		},
 		Opcode::EXTCODECOPY => {
-			let target = stack.peek(0)?.into();
+			let target = stack.peek_h256(0)?.into();
 			storage_target = StorageTarget::Address(target);
 			GasCost::ExtCodeCopy {
 				target_is_cold: handler.is_cold(target, None),
-				len: U256::from_big_endian(&stack.peek(3)?[..]),
+				len: stack.peek(3)?,
 			}
 		}
 		Opcode::CALLDATACOPY | Opcode::CODECOPY => GasCost::VeryLowCopy {
-			len: U256::from_big_endian(&stack.peek(2)?[..]),
+			len: stack.peek(2)?,
 		},
 		Opcode::EXP => GasCost::Exp {
-			power: U256::from_big_endian(&stack.peek(1)?[..]),
+			power: stack.peek(1)?,
 		},
 		Opcode::SLOAD => {
-			let index = stack.peek(0)?;
+			let index = stack.peek_h256(0)?;
 			storage_target = StorageTarget::Slot(address, index);
 			GasCost::SLoad {
 				target_is_cold: handler.is_cold(address, Some(index)),
@@ -534,10 +534,10 @@ pub fn dynamic_opcode_cost<H: Handler>(
 		}
 
 		Opcode::DELEGATECALL if config.has_delegate_call => {
-			let target = stack.peek(1)?.into();
+			let target = stack.peek_h256(1)?.into();
 			storage_target = StorageTarget::Address(target);
 			GasCost::DelegateCall {
-				gas: U256::from_big_endian(&stack.peek(0)?[..]),
+				gas: stack.peek(0)?,
 				target_is_cold: handler.is_cold(target, None),
 				target_exists: handler.exists(target),
 			}
@@ -546,13 +546,13 @@ pub fn dynamic_opcode_cost<H: Handler>(
 
 		Opcode::RETURNDATASIZE if config.has_return_data => GasCost::Base,
 		Opcode::RETURNDATACOPY if config.has_return_data => GasCost::VeryLowCopy {
-			len: U256::from_big_endian(&stack.peek(2)?[..]),
+			len: stack.peek(2)?,
 		},
 		Opcode::RETURNDATASIZE | Opcode::RETURNDATACOPY => GasCost::Invalid,
 
 		Opcode::SSTORE if !is_static => {
-			let index = stack.peek(0)?;
-			let value = stack.peek(1)?;
+			let index = stack.peek_h256(0)?;
+			let value = stack.peek_h256(1)?;
 			storage_target = StorageTarget::Slot(address, index);
 
 			GasCost::SStore {
@@ -564,30 +564,30 @@ pub fn dynamic_opcode_cost<H: Handler>(
 		}
 		Opcode::LOG0 if !is_static => GasCost::Log {
 			n: 0,
-			len: U256::from_big_endian(&stack.peek(1)?[..]),
+			len: stack.peek(1)?,
 		},
 		Opcode::LOG1 if !is_static => GasCost::Log {
 			n: 1,
-			len: U256::from_big_endian(&stack.peek(1)?[..]),
+			len: stack.peek(1)?,
 		},
 		Opcode::LOG2 if !is_static => GasCost::Log {
 			n: 2,
-			len: U256::from_big_endian(&stack.peek(1)?[..]),
+			len: stack.peek(1)?,
 		},
 		Opcode::LOG3 if !is_static => GasCost::Log {
 			n: 3,
-			len: U256::from_big_endian(&stack.peek(1)?[..]),
+			len: stack.peek(1)?,
 		},
 		Opcode::LOG4 if !is_static => GasCost::Log {
 			n: 4,
-			len: U256::from_big_endian(&stack.peek(1)?[..]),
+			len: stack.peek(1)?,
 		},
 		Opcode::CREATE if !is_static => GasCost::Create,
 		Opcode::CREATE2 if !is_static && config.has_create2 => GasCost::Create2 {
-			len: U256::from_big_endian(&stack.peek(2)?[..]),
+			len: stack.peek(2)?,
 		},
 		Opcode::SUICIDE if !is_static => {
-			let target = stack.peek(0)?.into();
+			let target = stack.peek_h256(0)?.into();
 			storage_target = StorageTarget::Address(target);
 			GasCost::Suicide {
 				value: handler.balance(address),
@@ -596,15 +596,12 @@ pub fn dynamic_opcode_cost<H: Handler>(
 				already_removed: handler.deleted(address),
 			}
 		}
-		Opcode::CALL
-			if !is_static
-				|| (is_static && U256::from_big_endian(&stack.peek(2)?[..]) == U256::zero()) =>
-		{
-			let target = stack.peek(1)?.into();
+		Opcode::CALL if !is_static || (is_static && stack.peek(2)? == U256::zero()) => {
+			let target = stack.peek_h256(1)?.into();
 			storage_target = StorageTarget::Address(target);
 			GasCost::Call {
-				value: U256::from_big_endian(&stack.peek(2)?[..]),
-				gas: U256::from_big_endian(&stack.peek(0)?[..]),
+				value: stack.peek(2)?,
+				gas: stack.peek(0)?,
 				target_is_cold: handler.is_cold(target, None),
 				target_exists: handler.exists(target),
 			}
@@ -622,54 +619,54 @@ pub fn dynamic_opcode_cost<H: Handler>(
 		| Opcode::LOG2
 		| Opcode::LOG3
 		| Opcode::LOG4 => Some(MemoryCost {
-			offset: U256::from_big_endian(&stack.peek(0)?[..]),
-			len: U256::from_big_endian(&stack.peek(1)?[..]),
+			offset: stack.peek(0)?,
+			len: stack.peek(1)?,
 		}),
 
 		Opcode::CODECOPY | Opcode::CALLDATACOPY | Opcode::RETURNDATACOPY => Some(MemoryCost {
-			offset: U256::from_big_endian(&stack.peek(0)?[..]),
-			len: U256::from_big_endian(&stack.peek(2)?[..]),
+			offset: stack.peek(0)?,
+			len: stack.peek(2)?,
 		}),
 
 		Opcode::EXTCODECOPY => Some(MemoryCost {
-			offset: U256::from_big_endian(&stack.peek(1)?[..]),
-			len: U256::from_big_endian(&stack.peek(3)?[..]),
+			offset: stack.peek(1)?,
+			len: stack.peek(3)?,
 		}),
 
 		Opcode::MLOAD | Opcode::MSTORE => Some(MemoryCost {
-			offset: U256::from_big_endian(&stack.peek(0)?[..]),
+			offset: stack.peek(0)?,
 			len: U256::from(32),
 		}),
 
 		Opcode::MSTORE8 => Some(MemoryCost {
-			offset: U256::from_big_endian(&stack.peek(0)?[..]),
+			offset: stack.peek(0)?,
 			len: U256::from(1),
 		}),
 
 		Opcode::CREATE | Opcode::CREATE2 => Some(MemoryCost {
-			offset: U256::from_big_endian(&stack.peek(1)?[..]),
-			len: U256::from_big_endian(&stack.peek(2)?[..]),
+			offset: stack.peek(1)?,
+			len: stack.peek(2)?,
 		}),
 
 		Opcode::CALL | Opcode::CALLCODE => Some(
 			MemoryCost {
-				offset: U256::from_big_endian(&stack.peek(3)?[..]),
-				len: U256::from_big_endian(&stack.peek(4)?[..]),
+				offset: stack.peek(3)?,
+				len: stack.peek(4)?,
 			}
 			.join(MemoryCost {
-				offset: U256::from_big_endian(&stack.peek(5)?[..]),
-				len: U256::from_big_endian(&stack.peek(6)?[..]),
+				offset: stack.peek(5)?,
+				len: stack.peek(6)?,
 			}),
 		),
 
 		Opcode::DELEGATECALL | Opcode::STATICCALL => Some(
 			MemoryCost {
-				offset: U256::from_big_endian(&stack.peek(2)?[..]),
-				len: U256::from_big_endian(&stack.peek(3)?[..]),
+				offset: stack.peek(2)?,
+				len: stack.peek(3)?,
 			}
 			.join(MemoryCost {
-				offset: U256::from_big_endian(&stack.peek(4)?[..]),
-				len: U256::from_big_endian(&stack.peek(5)?[..]),
+				offset: stack.peek(4)?,
+				len: stack.peek(5)?,
 			}),
 		),
 

--- a/runtime/src/eval/macros.rs
+++ b/runtime/src/eval/macros.rs
@@ -7,11 +7,15 @@ macro_rules! try_or_fail {
 	};
 }
 
-macro_rules! pop {
+macro_rules! pop_h256 {
 	( $machine:expr, $( $x:ident ),* ) => (
 		$(
 			let $x = match $machine.machine.stack_mut().pop() {
-				Ok(value) => value,
+				Ok(value) => {
+					let mut res = H256([0; 32]);
+					value.to_big_endian(&mut res[..]);
+					res
+				},
 				Err(e) => return Control::Exit(e.into()),
 			};
 		)*
@@ -22,17 +26,17 @@ macro_rules! pop_u256 {
 	( $machine:expr, $( $x:ident ),* ) => (
 		$(
 			let $x = match $machine.machine.stack_mut().pop() {
-				Ok(value) => U256::from_big_endian(&value[..]),
+				Ok(value) => value,
 				Err(e) => return Control::Exit(e.into()),
 			};
 		)*
 	);
 }
 
-macro_rules! push {
+macro_rules! push_h256 {
 	( $machine:expr, $( $x:expr ),* ) => (
 		$(
-			match $machine.machine.stack_mut().push($x) {
+			match $machine.machine.stack_mut().push(U256::from_big_endian(&$x[..])) {
 				Ok(()) => (),
 				Err(e) => return Control::Exit(e.into()),
 			}
@@ -43,9 +47,7 @@ macro_rules! push {
 macro_rules! push_u256 {
 	( $machine:expr, $( $x:expr ),* ) => (
 		$(
-			let mut value = H256::default();
-			$x.to_big_endian(&mut value[..]);
-			match $machine.machine.stack_mut().push(value) {
+			match $machine.machine.stack_mut().push($x) {
 				Ok(()) => (),
 				Err(e) => return Control::Exit(e.into()),
 			}

--- a/runtime/src/eval/system.rs
+++ b/runtime/src/eval/system.rs
@@ -22,7 +22,7 @@ pub fn sha3<H: Handler>(runtime: &mut Runtime) -> Control<H> {
 	};
 
 	let ret = Keccak256::digest(data.as_slice());
-	push!(runtime, H256::from_slice(ret.as_slice()));
+	push_h256!(runtime, H256::from_slice(ret.as_slice()));
 
 	Control::Continue
 }
@@ -35,13 +35,13 @@ pub fn chainid<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 
 pub fn address<H: Handler>(runtime: &mut Runtime) -> Control<H> {
 	let ret = H256::from(runtime.context.address);
-	push!(runtime, ret);
+	push_h256!(runtime, ret);
 
 	Control::Continue
 }
 
 pub fn balance<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
-	pop!(runtime, address);
+	pop_h256!(runtime, address);
 	push_u256!(runtime, handler.balance(address.into()));
 
 	Control::Continue
@@ -55,14 +55,14 @@ pub fn selfbalance<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H>
 
 pub fn origin<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	let ret = H256::from(handler.origin());
-	push!(runtime, ret);
+	push_h256!(runtime, ret);
 
 	Control::Continue
 }
 
 pub fn caller<H: Handler>(runtime: &mut Runtime) -> Control<H> {
 	let ret = H256::from(runtime.context.caller);
-	push!(runtime, ret);
+	push_h256!(runtime, ret);
 
 	Control::Continue
 }
@@ -70,7 +70,7 @@ pub fn caller<H: Handler>(runtime: &mut Runtime) -> Control<H> {
 pub fn callvalue<H: Handler>(runtime: &mut Runtime) -> Control<H> {
 	let mut ret = H256::default();
 	runtime.context.apparent_value.to_big_endian(&mut ret[..]);
-	push!(runtime, ret);
+	push_h256!(runtime, ret);
 
 	Control::Continue
 }
@@ -78,7 +78,7 @@ pub fn callvalue<H: Handler>(runtime: &mut Runtime) -> Control<H> {
 pub fn gasprice<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	let mut ret = H256::default();
 	handler.gas_price().to_big_endian(&mut ret[..]);
-	push!(runtime, ret);
+	push_h256!(runtime, ret);
 
 	Control::Continue
 }
@@ -86,27 +86,27 @@ pub fn gasprice<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 pub fn base_fee<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	let mut ret = H256::default();
 	handler.block_base_fee_per_gas().to_big_endian(&mut ret[..]);
-	push!(runtime, ret);
+	push_h256!(runtime, ret);
 
 	Control::Continue
 }
 
 pub fn extcodesize<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
-	pop!(runtime, address);
+	pop_h256!(runtime, address);
 	push_u256!(runtime, handler.code_size(address.into()));
 
 	Control::Continue
 }
 
 pub fn extcodehash<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
-	pop!(runtime, address);
-	push!(runtime, handler.code_hash(address.into()));
+	pop_h256!(runtime, address);
+	push_h256!(runtime, handler.code_hash(address.into()));
 
 	Control::Continue
 }
 
 pub fn extcodecopy<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
-	pop!(runtime, address);
+	pop_h256!(runtime, address);
 	pop_u256!(runtime, memory_offset, code_offset, len);
 
 	try_or_fail!(runtime
@@ -161,13 +161,13 @@ pub fn returndatacopy<H: Handler>(runtime: &mut Runtime) -> Control<H> {
 
 pub fn blockhash<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	pop_u256!(runtime, number);
-	push!(runtime, handler.block_hash(number));
+	push_h256!(runtime, handler.block_hash(number));
 
 	Control::Continue
 }
 
 pub fn coinbase<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
-	push!(runtime, handler.block_coinbase().into());
+	push_h256!(runtime, handler.block_coinbase().into());
 	Control::Continue
 }
 
@@ -192,9 +192,9 @@ pub fn gaslimit<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 }
 
 pub fn sload<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
-	pop!(runtime, index);
+	pop_h256!(runtime, index);
 	let value = handler.storage(runtime.context.address, index);
-	push!(runtime, value);
+	push_h256!(runtime, value);
 
 	event!(SLoad {
 		address: runtime.context.address,
@@ -206,7 +206,7 @@ pub fn sload<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 }
 
 pub fn sstore<H: Handler>(runtime: &mut Runtime, handler: &mut H) -> Control<H> {
-	pop!(runtime, index, value);
+	pop_h256!(runtime, index, value);
 
 	event!(SStore {
 		address: runtime.context.address,
@@ -241,7 +241,7 @@ pub fn log<H: Handler>(runtime: &mut Runtime, n: u8, handler: &mut H) -> Control
 
 	let mut topics = Vec::new();
 	for _ in 0..(n as usize) {
-		match runtime.machine.stack_mut().pop() {
+		match runtime.machine.stack_mut().pop_h256() {
 			Ok(value) => {
 				topics.push(value);
 			}
@@ -256,7 +256,7 @@ pub fn log<H: Handler>(runtime: &mut Runtime, n: u8, handler: &mut H) -> Control
 }
 
 pub fn suicide<H: Handler>(runtime: &mut Runtime, handler: &mut H) -> Control<H> {
-	pop!(runtime, target);
+	pop_h256!(runtime, target);
 
 	match handler.mark_delete(runtime.context.address, target.into()) {
 		Ok(()) => (),
@@ -282,7 +282,7 @@ pub fn create<H: Handler>(runtime: &mut Runtime, is_create2: bool, handler: &mut
 	};
 
 	let scheme = if is_create2 {
-		pop!(runtime, salt);
+		pop_h256!(runtime, salt);
 		let code_hash = H256::from_slice(Keccak256::digest(&code).as_slice());
 		CreateScheme::Create2 {
 			caller: runtime.context.address,
@@ -302,25 +302,25 @@ pub fn create<H: Handler>(runtime: &mut Runtime, is_create2: bool, handler: &mut
 
 			match reason {
 				ExitReason::Succeed(_) => {
-					push!(runtime, create_address);
+					push_h256!(runtime, create_address);
 					Control::Continue
 				}
 				ExitReason::Revert(_) => {
-					push!(runtime, H256::default());
+					push_h256!(runtime, H256::default());
 					Control::Continue
 				}
 				ExitReason::Error(_) => {
-					push!(runtime, H256::default());
+					push_h256!(runtime, H256::default());
 					Control::Continue
 				}
 				ExitReason::Fatal(e) => {
-					push!(runtime, H256::default());
+					push_h256!(runtime, H256::default());
 					Control::Exit(e.into())
 				}
 			}
 		}
 		Capture::Trap(interrupt) => {
-			push!(runtime, H256::default());
+			push_h256!(runtime, H256::default());
 			Control::CreateInterrupt(interrupt)
 		}
 	}
@@ -330,7 +330,7 @@ pub fn call<H: Handler>(runtime: &mut Runtime, scheme: CallScheme, handler: &mut
 	runtime.return_data_buffer = Vec::new();
 
 	pop_u256!(runtime, gas);
-	pop!(runtime, to);
+	pop_h256!(runtime, to);
 	let gas = if gas > U256::from(u64::MAX) {
 		None
 	} else {
@@ -454,7 +454,7 @@ pub fn call<H: Handler>(runtime: &mut Runtime, scheme: CallScheme, handler: &mut
 			}
 		}
 		Capture::Trap(interrupt) => {
-			push!(runtime, H256::default());
+			push_h256!(runtime, H256::default());
 			Control::CallInterrupt(interrupt)
 		}
 	}

--- a/runtime/src/eval/system.rs
+++ b/runtime/src/eval/system.rs
@@ -167,7 +167,7 @@ pub fn blockhash<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 }
 
 pub fn coinbase<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
-	push_h256!(runtime, handler.block_coinbase().into());
+	push_h256!(runtime, handler.block_coinbase());
 	Control::Continue
 }
 


### PR DESCRIPTION
H256 is [u8; 32]
U256 is [u64; 4]

According to EVM spec, when H256 is interpreted as a number, the byte
order is big endian. WASM, in contrast, uses little-endian
representation (the same used by CPUs internally).

Before this PR, evm stored operand stack as `Vec<H256>`, so any
arithmetic op entailed indianness conversion. As WASM lacks equivalent
to bswap instruction, this is a lot of work.

After this PR, stack is using U256 (so, little-endian in memory). This
is also reperesentation used by all of geth, evmone and odin.

For the uniswap benchmark, the before-after WASM (not total) gas cost is

110436615921984
 90540800264244

Notes: 

* I've made this on top of https://github.com/rust-blockchain/evm/pull/97
* I think it also makes sense to rename macros further (`pop_u256` -> `pop`), such that we only use a suffix for non-standard operation. I didn't do this in the PR to minimize diff.
* I think this should be upstreamable. The fact that both geth and evmone use little-endian stack seems to me a very strong argument that this is a generally good idea.
* $DEITY bless strong types! The fact that `H256` and `U256` are different types makes me so much more confident in this change! 

