### PR TITLE
Use usize rather than u256 for memory offsets

### DIFF
--- a/core/src/eval/macros.rs
+++ b/core/src/eval/macros.rs
@@ -55,6 +55,21 @@ macro_rules! push_u256 {
 	)
 }
 
+/// Pops top element of the stack and converts it to `usize`.
+///
+/// The top element **must** be not greater than `usize::MAX`.
+/// This non-local invariant is enforced by gas metering infrastructure.
+macro_rules! pop_usize {
+	( $machine:expr, $( $x:ident ),* ) => (
+		$(
+			let $x = match $machine.stack.pop() {
+				Ok(value) => value.as_usize(),
+				Err(e) => return Control::Exit(e.into()),
+			};
+		)*
+	);
+}
+
 macro_rules! op1_u256_fn {
 	( $machine:expr, $op:path ) => {{
 		pop_u256!($machine, op1);

--- a/core/src/eval/misc.rs
+++ b/core/src/eval/misc.rs
@@ -1,5 +1,5 @@
 use super::Control;
-use crate::{ExitError, ExitFatal, ExitRevert, ExitSucceed, Machine};
+use crate::{ExitError, ExitRevert, ExitSucceed, Machine};
 use core::cmp::min;
 use primitive_types::{H256, U256};
 
@@ -12,7 +12,9 @@ pub fn codesize(state: &mut Machine) -> Control {
 
 #[inline]
 pub fn codecopy(state: &mut Machine) -> Control {
-	pop_u256!(state, memory_offset, code_offset, len);
+	pop_usize!(state, memory_offset);
+	pop_u256!(state, code_offset);
+	pop_usize!(state, len);
 
 	try_or_fail!(state.memory.resize_offset(memory_offset, len));
 	match state
@@ -54,10 +56,12 @@ pub fn calldatasize(state: &mut Machine) -> Control {
 
 #[inline]
 pub fn calldatacopy(state: &mut Machine) -> Control {
-	pop_u256!(state, memory_offset, data_offset, len);
+	pop_usize!(state, memory_offset);
+	pop_u256!(state, data_offset);
+	pop_usize!(state, len);
 
 	try_or_fail!(state.memory.resize_offset(memory_offset, len));
-	if len == U256::zero() {
+	if len == 0 {
 		return Control::Continue(1);
 	}
 
@@ -78,9 +82,8 @@ pub fn pop(state: &mut Machine) -> Control {
 
 #[inline]
 pub fn mload(state: &mut Machine) -> Control {
-	pop_u256!(state, index);
-	try_or_fail!(state.memory.resize_offset(index, U256::from(32)));
-	let index = as_usize_or_fail!(index);
+	pop_usize!(state, index);
+	try_or_fail!(state.memory.resize_offset(index, 32));
 	let value = state.memory.get_h256(index);
 	push_h256!(state, value);
 	Control::Continue(1)
@@ -88,10 +91,9 @@ pub fn mload(state: &mut Machine) -> Control {
 
 #[inline]
 pub fn mstore(state: &mut Machine) -> Control {
-	pop_u256!(state, index);
+	pop_usize!(state, index);
 	pop_h256!(state, value);
-	try_or_fail!(state.memory.resize_offset(index, U256::from(32)));
-	let index = as_usize_or_fail!(index);
+	try_or_fail!(state.memory.resize_offset(index, 32));
 	match state.memory.set(index, &value[..], Some(32)) {
 		Ok(()) => Control::Continue(1),
 		Err(e) => Control::Exit(e.into()),
@@ -100,9 +102,9 @@ pub fn mstore(state: &mut Machine) -> Control {
 
 #[inline]
 pub fn mstore8(state: &mut Machine) -> Control {
-	pop_u256!(state, index, value);
-	try_or_fail!(state.memory.resize_offset(index, U256::one()));
-	let index = as_usize_or_fail!(index);
+	pop_usize!(state, index);
+	pop_u256!(state, value);
+	try_or_fail!(state.memory.resize_offset(index, 1));
 	let value = (value.low_u32() & 0xff) as u8;
 	match state.memory.set(index, &[value], Some(1)) {
 		Ok(()) => Control::Continue(1),
@@ -147,7 +149,7 @@ pub fn pc(state: &mut Machine, position: usize) -> Control {
 
 #[inline]
 pub fn msize(state: &mut Machine) -> Control {
-	push_u256!(state, state.memory.effective_len());
+	push_u256!(state, state.memory.effective_len().into());
 	Control::Continue(1)
 }
 
@@ -194,16 +196,16 @@ pub fn swap(state: &mut Machine, n: usize) -> Control {
 
 #[inline]
 pub fn ret(state: &mut Machine) -> Control {
-	pop_u256!(state, start, len);
+	pop_usize!(state, start, len);
 	try_or_fail!(state.memory.resize_offset(start, len));
-	state.return_range = start..(start + len);
+	state.return_range = start.into()..(start + len).into();
 	Control::Exit(ExitSucceed::Returned.into())
 }
 
 #[inline]
 pub fn revert(state: &mut Machine) -> Control {
-	pop_u256!(state, start, len);
+	pop_usize!(state, start, len);
 	try_or_fail!(state.memory.resize_offset(start, len));
-	state.return_range = start..(start + len);
+	state.return_range = start.into()..(start + len).into();
 	Control::Exit(ExitRevert::Reverted.into())
 }

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -9,7 +9,7 @@ use primitive_types::{H256, U256};
 #[derive(Clone, Debug)]
 pub struct Memory {
 	data: Vec<u8>,
-	effective_len: U256,
+	effective_len: usize,
 	limit: usize,
 }
 
@@ -18,7 +18,7 @@ impl Memory {
 	pub fn new(limit: usize) -> Self {
 		Self {
 			data: Vec::new(),
-			effective_len: U256::zero(),
+			effective_len: 0,
 			limit,
 		}
 	}
@@ -34,7 +34,7 @@ impl Memory {
 	}
 
 	/// Get the effective length.
-	pub fn effective_len(&self) -> U256 {
+	pub fn effective_len(&self) -> usize {
 		self.effective_len
 	}
 
@@ -51,8 +51,8 @@ impl Memory {
 	/// Resize the memory, making it cover the memory region of `offset..(offset
 	/// + len)`, with 32 bytes as the step. If the length is zero, this function
 	/// does nothing.
-	pub fn resize_offset(&mut self, offset: U256, len: U256) -> Result<(), ExitError> {
-		if len == U256::zero() {
+	pub fn resize_offset(&mut self, offset: usize, len: usize) -> Result<(), ExitError> {
+		if len == 0 {
 			return Ok(());
 		}
 
@@ -64,7 +64,7 @@ impl Memory {
 	}
 
 	/// Resize the memory, making it cover to `end`, with 32 bytes as the step.
-	pub fn resize_end(&mut self, end: U256) -> Result<(), ExitError> {
+	pub fn resize_end(&mut self, end: usize) -> Result<(), ExitError> {
 		if end > self.effective_len {
 			let new_end = next_multiple_of_32(end).ok_or(ExitError::InvalidRange)?;
 			self.effective_len = new_end;
@@ -153,9 +153,9 @@ impl Memory {
 	/// Copy `data` into the memory, of given `len`.
 	pub fn copy_large(
 		&mut self,
-		memory_offset: U256,
+		memory_offset: usize,
 		data_offset: U256,
-		len: U256,
+		len: usize,
 		data: &[u8],
 	) -> Result<(), ExitFatal> {
 		// Needed to pass ethereum test defined in
@@ -163,23 +163,11 @@ impl Memory {
 		// (regardless of other inputs, a zero-length copy is defined to be a no-op).
 		// TODO: refactor `set` and `copy_large` (see
 		// https://github.com/rust-blockchain/evm/pull/40#discussion_r677180794)
-		if len.is_zero() {
+		if len == 0 {
 			return Ok(());
 		}
 
-		let memory_offset = if memory_offset > U256::from(usize::MAX) {
-			return Err(ExitFatal::NotSupported);
-		} else {
-			memory_offset.as_usize()
-		};
-
-		let ulen = if len > U256::from(usize::MAX) {
-			return Err(ExitFatal::NotSupported);
-		} else {
-			len.as_usize()
-		};
-
-		let data = if let Some(end) = data_offset.checked_add(len) {
+		let data = if let Some(end) = data_offset.checked_add(len.into()) {
 			if end > U256::from(usize::MAX) {
 				&[]
 			} else {
@@ -196,26 +184,26 @@ impl Memory {
 			&[]
 		};
 
-		self.set(memory_offset, data, Some(ulen))
+		self.set(memory_offset, data, Some(len))
 	}
 }
 
 /// Rounds up `x` to the closest multiple of 32. If `x % 32 == 0` then `x` is returned.
 #[inline]
-fn next_multiple_of_32(x: U256) -> Option<U256> {
-	let r = x.low_u32().bitand(31).not().wrapping_add(1).bitand(31);
-	x.checked_add(r.into())
+fn next_multiple_of_32(x: usize) -> Option<usize> {
+	let r = x.bitand(31).not().wrapping_add(1).bitand(31);
+	x.checked_add(r)
 }
 
 #[cfg(test)]
 mod tests {
-	use super::{next_multiple_of_32, U256};
+	use super::next_multiple_of_32;
 
 	#[test]
 	fn test_next_multiple_of_32() {
 		// next_multiple_of_32 returns x when it is a multiple of 32
 		for i in 0..32 {
-			let x = U256::from(i * 32);
+			let x = i * 32;
 			assert_eq!(Some(x), next_multiple_of_32(x));
 		}
 
@@ -226,15 +214,15 @@ mod tests {
 			}
 			let next_multiple = x + 32 - (x % 32);
 			assert_eq!(
-				Some(U256::from(next_multiple)),
+				Some(next_multiple),
 				next_multiple_of_32(x.into())
 			);
 		}
 
 		// next_multiple_of_32 returns None when the next multiple of 32 is too big
-		let last_multiple_of_32 = U256::MAX & !U256::from(31);
+		let last_multiple_of_32 = usize::MAX & !31;
 		for i in 0..63 {
-			let x = U256::MAX - U256::from(i);
+			let x = usize::MAX - i;
 			if x > last_multiple_of_32 {
 				assert_eq!(None, next_multiple_of_32(x));
 			} else {

--- a/core/src/stack.rs
+++ b/core/src/stack.rs
@@ -94,6 +94,18 @@ impl Stack {
 	}
 
 	#[inline]
+	/// Peek a value at given index for the stack as usize.
+	///
+	/// If the value is larger than `usize::MAX`, `OutOfGas` error is returned.
+	pub fn peek_usize(&self, no_from_top: usize) -> Result<usize, ExitError> {
+		let u = self.peek(no_from_top)?;
+		if u > usize::MAX.into() {
+			return Err(ExitError::OutOfGas);
+		}
+		Ok(u.as_usize())
+	}
+
+	#[inline]
 	/// Set a value at given index for the stack, where the top of the
 	/// stack is at index `0`. If the index is too large,
 	/// `StackError::Underflow` is returned.

--- a/runtime/src/eval/macros.rs
+++ b/runtime/src/eval/macros.rs
@@ -55,20 +55,18 @@ macro_rules! push_u256 {
 	)
 }
 
-macro_rules! as_usize_or_fail {
-	( $v:expr ) => {{
-		if $v > U256::from(usize::MAX) {
-			return Control::Exit(ExitFatal::NotSupported.into());
-		}
-
-		$v.as_usize()
-	}};
-
-	( $v:expr, $reason:expr ) => {{
-		if $v > U256::from(usize::MAX) {
-			return Control::Exit($reason.into());
-		}
-
-		$v.as_usize()
-	}};
+/// Pops top element of the stack and converts it to `usize`.
+///
+/// The top element **must** be not greater than `usize::MAX`.
+/// This non-local invariant is enforced by gas metering infrastructure.
+macro_rules! pop_usize {
+	( $machine:expr, $( $x:ident ),* ) => (
+		$(
+			let $x = match $machine.machine.stack_mut().pop() {
+				Ok(value) => value.as_usize(),
+				Err(e) => return Control::Exit(e.into()),
+			};
+		)*
+	);
 }
+


### PR DESCRIPTION
This change improves performance (as measured by the number of WASM
instructions executed) by about 5%.

The story here is that memory-related operations, notably mload and
mstore, are pretty high in profiles. Part of the reason for that is that
offsets are represented as U256, and carrying out bounds checking in
wide integers is naturally slow!

Luckily, we actually know that all actual addresses will fit in usize --
bigger addresses *must* run out of gas. So, in this PR we do two things:

* when calculating memory-related gas usage, convert u256 to usize as
  early as possible, flagging overflows as out of gas errors.
* when executing memory-related instructions, *assume* that operands fit
  usize and just cast them (we use checked cast, so we'll panic if
  that's not the case. Replacing that with unchecked cast leads to just
  a tiny further perf improvement).

I am not entirely thrilled by this non-local invariant. It'd be much
better if gas counting and execution were defined by the same function,
so as to make the invariant local. Still, I think the current impl is
fine:

Even in the original impl, we had a similar implicit invariant
(as_usize_or_fail was casting u256 to usize). The official geth impl
seems to do roughly the same thing. As far as I understand, they even
use unchecked casts!