### PR TITLE
perf: reduce Result checks in Gasometer

### DIFF
--- a/gasometer/src/lib.rs
+++ b/gasometer/src/lib.rs
@@ -54,6 +54,18 @@ pub struct Snapshot {
 	pub refunded_gas: i64,
 }
 
+#[cfg(feature = "tracing")]
+impl Snapshot {
+	fn new<'config>(gas_limit: u64, inner: &'config Inner<'config>) -> Snapshot {
+		Snapshot {
+			gas_limit,
+			memory_gas: inner.memory_gas,
+			used_gas: inner.used_gas,
+			refunded_gas: inner.refunded_gas,
+		}
+	}
+}
+
 /// EVM gasometer.
 #[derive(Clone, Debug)]
 pub struct Gasometer<'config> {
@@ -180,20 +192,28 @@ impl<'config> Gasometer<'config> {
 		memory: Option<MemoryCost>,
 	) -> Result<(), ExitError> {
 		let gas = self.gas();
+		// Extract a mutable reference to `Inner` to avoid checking `Result`
+		// repeatedly. Tuning performance as this function is on the hot path.
+		let mut inner_mut = match &mut self.inner {
+			Ok(inner) => inner,
+			Err(err) => return Err(err.clone()),
+		};
 
 		let memory_gas = match memory {
-			Some(memory) => try_or_fail!(self.inner, self.inner_mut()?.memory_gas(memory)),
-			None => self.inner_mut()?.memory_gas,
+			Some(memory) => try_or_fail!(self.inner, inner_mut.memory_gas(memory)),
+			None => inner_mut.memory_gas,
 		};
-		let gas_cost = try_or_fail!(self.inner, self.inner_mut()?.gas_cost(cost, gas));
-		let gas_refund = self.inner_mut()?.gas_refund(cost);
-		let used_gas = self.inner_mut()?.used_gas;
+		let gas_cost = try_or_fail!(self.inner, inner_mut.gas_cost(cost, gas));
+		let gas_refund = inner_mut.gas_refund(cost);
+		let used_gas = inner_mut.used_gas;
 
+		#[cfg(feature = "tracing")]
+		let gas_limit = self.gas_limit;
 		event!(RecordDynamicCost {
 			gas_cost,
 			memory_gas,
 			gas_refund,
-			snapshot: self.snapshot(),
+			snapshot: Some(Snapshot::new(gas_limit, inner_mut)),
 		});
 
 		let all_gas_cost = memory_gas + used_gas + gas_cost;
@@ -203,11 +223,11 @@ impl<'config> Gasometer<'config> {
 		}
 
 		let after_gas = self.gas_limit - all_gas_cost;
-		try_or_fail!(self.inner, self.inner_mut()?.extra_check(cost, after_gas));
+		try_or_fail!(self.inner, inner_mut.extra_check(cost, after_gas));
 
-		self.inner_mut()?.used_gas += gas_cost;
-		self.inner_mut()?.memory_gas = memory_gas;
-		self.inner_mut()?.refunded_gas += gas_refund;
+		inner_mut.used_gas += gas_cost;
+		inner_mut.memory_gas = memory_gas;
+		inner_mut.refunded_gas += gas_refund;
 
 		Ok(())
 	}
@@ -269,12 +289,10 @@ impl<'config> Gasometer<'config> {
 
 	#[cfg(feature = "tracing")]
 	pub fn snapshot(&self) -> Option<Snapshot> {
-		self.inner.as_ref().ok().map(|inner| Snapshot {
-			gas_limit: self.gas_limit,
-			memory_gas: inner.memory_gas,
-			used_gas: inner.used_gas,
-			refunded_gas: inner.refunded_gas,
-		})
+		self.inner
+			.as_ref()
+			.ok()
+			.map(|inner| Snapshot::new(self.gas_limit, inner))
 	}
 }
 


### PR DESCRIPTION
`Gasometer` has a field `inner: Result<Inner<'config>, ExitError>`. That
field is often accessed in `Gasometer`'s method `record_dynamic_cost`, which
involves a lot of `?` operators. This was identified as inefficiency in [#448](https://github.com/aurora-is-near/aurora-engine/issues/448) (2nd item).

To improve performance, a mutable reference to `Inner` is stored in a variable
and used througout `record_dynamic_cost`, which allows to remove most `?` in
that method.

`Snapshot::new()` is added to avoid ownership issues when compiling with
`--features tracing`. `Gasometer::snapshot()` borrows `self`, which can be
avoided by using `Snapshot::new` instead.

# NEAR gas reductions
Including this in `aurora-engine` makes the following tests fail due to NEAR gas
usage which is _lower_ than the expected numbers:

```
tests::one_inch::test_1inch_liquidity_protocol
tests::repro::repro_5bEgfRQ
tests::repro::repro_8ru7VEA
tests::repro::repro_D98vwmi
tests::repro::repro_FRcorNv
tests::repro::repro_GdASJ3KESs
tests::uniswap::test_uniswap_exact_output
tests::uniswap::test_uniswap_input_multihop
```

## Reproduction
```
tree
.
├── aurora-engine # @ develop branch
├── sputnikvm     # containing this PR's modifications
```

Patch `aurora-engine` to include the locally modified `sputnikvm`:

```diff
diff --git a/Cargo.toml b/Cargo.toml
index f27de56..1f4bedf 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,12 @@ rpath = false
 lto = true
 opt-level = 3
 
+[patch.'https://github.com/aurora-is-near/sputnikvm.git']
+evm = { path = "../sputnikvm" }
+evm-core = { path = "../sputnikvm/core" }
+evm-gasometer = { path = "../sputnikvm/gasometer" }
+evm-runtime = { path = "../sputnikvm/runtime" }
+
 [workspace]
 resolver = "2"
 members = [
```

Run tests with:
```
cd aurora-engine
make check
```
