### PR TITLE
perf: make Stack::peek() return a reference

### DIFF
--- a/core/src/eval/misc.rs
+++ b/core/src/eval/misc.rs
@@ -183,7 +183,7 @@ pub fn push2(state: &mut Machine, position: usize) -> Control {
 #[inline]
 pub fn dup(state: &mut Machine, n: usize) -> Control {
 	let value = match state.stack.peek(n - 1) {
-		Ok(value) => value,
+		Ok(&value) => value,
 		Err(e) => return Control::Exit(e.into()),
 	};
 	push_u256!(state, value);
@@ -193,11 +193,11 @@ pub fn dup(state: &mut Machine, n: usize) -> Control {
 #[inline]
 pub fn swap(state: &mut Machine, n: usize) -> Control {
 	let val1 = match state.stack.peek(0) {
-		Ok(value) => value,
+		Ok(&value) => value,
 		Err(e) => return Control::Exit(e.into()),
 	};
 	let val2 = match state.stack.peek(n) {
-		Ok(value) => value,
+		Ok(&value) => value,
 		Err(e) => return Control::Exit(e.into()),
 	};
 	match state.stack.set(0, val2) {

--- a/core/src/stack.rs
+++ b/core/src/stack.rs
@@ -73,9 +73,9 @@ impl Stack {
 	/// Peek a value at given index for the stack, where the top of
 	/// the stack is at index `0`. If the index is too large,
 	/// `StackError::Underflow` is returned.
-	pub fn peek(&self, no_from_top: usize) -> Result<U256, ExitError> {
+	pub fn peek(&self, no_from_top: usize) -> Result<&U256, ExitError> {
 		if self.data.len() > no_from_top {
-			Ok(self.data[self.data.len() - no_from_top - 1])
+			Ok(&self.data[self.data.len() - no_from_top - 1])
 		} else {
 			Err(ExitError::StackUnderflow)
 		}

--- a/gasometer/src/lib.rs
+++ b/gasometer/src/lib.rs
@@ -499,8 +499,8 @@ pub fn dynamic_opcode_cost<H: Handler>(
 			let target = stack.peek_h256(1)?.into();
 			storage_target = StorageTarget::Address(target);
 			GasCost::CallCode {
-				value: stack.peek(2)?,
-				gas: stack.peek(0)?,
+				value: *stack.peek(2)?,
+				gas: *stack.peek(0)?,
 				target_is_cold: handler.is_cold(target, None),
 				target_exists: handler.exists(target),
 			}
@@ -509,27 +509,27 @@ pub fn dynamic_opcode_cost<H: Handler>(
 			let target = stack.peek_h256(1)?.into();
 			storage_target = StorageTarget::Address(target);
 			GasCost::StaticCall {
-				gas: stack.peek(0)?,
+				gas: *stack.peek(0)?,
 				target_is_cold: handler.is_cold(target, None),
 				target_exists: handler.exists(target),
 			}
 		}
 		Opcode::SHA3 => GasCost::Sha3 {
-			len: stack.peek(1)?,
+			len: *stack.peek(1)?,
 		},
 		Opcode::EXTCODECOPY => {
 			let target = stack.peek_h256(0)?.into();
 			storage_target = StorageTarget::Address(target);
 			GasCost::ExtCodeCopy {
 				target_is_cold: handler.is_cold(target, None),
-				len: stack.peek(3)?,
+				len: *stack.peek(3)?,
 			}
 		}
 		Opcode::CALLDATACOPY | Opcode::CODECOPY => GasCost::VeryLowCopy {
-			len: stack.peek(2)?,
+			len: *stack.peek(2)?,
 		},
 		Opcode::EXP => GasCost::Exp {
-			power: stack.peek(1)?,
+			power: *stack.peek(1)?,
 		},
 		Opcode::SLOAD => {
 			let index = stack.peek_h256(0)?;
@@ -543,7 +543,7 @@ pub fn dynamic_opcode_cost<H: Handler>(
 			let target = stack.peek_h256(1)?.into();
 			storage_target = StorageTarget::Address(target);
 			GasCost::DelegateCall {
-				gas: stack.peek(0)?,
+				gas: *stack.peek(0)?,
 				target_is_cold: handler.is_cold(target, None),
 				target_exists: handler.exists(target),
 			}
@@ -552,7 +552,7 @@ pub fn dynamic_opcode_cost<H: Handler>(
 
 		Opcode::RETURNDATASIZE if config.has_return_data => GasCost::Base,
 		Opcode::RETURNDATACOPY if config.has_return_data => GasCost::VeryLowCopy {
-			len: stack.peek(2)?,
+			len: *stack.peek(2)?,
 		},
 		Opcode::RETURNDATASIZE | Opcode::RETURNDATACOPY => GasCost::Invalid,
 
@@ -570,27 +570,27 @@ pub fn dynamic_opcode_cost<H: Handler>(
 		}
 		Opcode::LOG0 if !is_static => GasCost::Log {
 			n: 0,
-			len: stack.peek(1)?,
+			len: *stack.peek(1)?,
 		},
 		Opcode::LOG1 if !is_static => GasCost::Log {
 			n: 1,
-			len: stack.peek(1)?,
+			len: *stack.peek(1)?,
 		},
 		Opcode::LOG2 if !is_static => GasCost::Log {
 			n: 2,
-			len: stack.peek(1)?,
+			len: *stack.peek(1)?,
 		},
 		Opcode::LOG3 if !is_static => GasCost::Log {
 			n: 3,
-			len: stack.peek(1)?,
+			len: *stack.peek(1)?,
 		},
 		Opcode::LOG4 if !is_static => GasCost::Log {
 			n: 4,
-			len: stack.peek(1)?,
+			len: *stack.peek(1)?,
 		},
 		Opcode::CREATE if !is_static => GasCost::Create,
 		Opcode::CREATE2 if !is_static && config.has_create2 => GasCost::Create2 {
-			len: stack.peek(2)?,
+			len: *stack.peek(2)?,
 		},
 		Opcode::SUICIDE if !is_static => {
 			let target = stack.peek_h256(0)?.into();
@@ -602,12 +602,12 @@ pub fn dynamic_opcode_cost<H: Handler>(
 				already_removed: handler.deleted(address),
 			}
 		}
-		Opcode::CALL if !is_static || (is_static && stack.peek(2)? == U256::zero()) => {
+		Opcode::CALL if !is_static || (is_static && *stack.peek(2)? == U256::zero()) => {
 			let target = stack.peek_h256(1)?.into();
 			storage_target = StorageTarget::Address(target);
 			GasCost::Call {
-				value: stack.peek(2)?,
-				gas: stack.peek(0)?,
+				value: *stack.peek(2)?,
+				gas: *stack.peek(0)?,
 				target_is_cold: handler.is_cold(target, None),
 				target_exists: handler.exists(target),
 			}
@@ -625,54 +625,54 @@ pub fn dynamic_opcode_cost<H: Handler>(
 		| Opcode::LOG2
 		| Opcode::LOG3
 		| Opcode::LOG4 => Some(MemoryCost {
-			offset: stack.peek(0)?,
-			len: stack.peek(1)?,
+			offset: *stack.peek(0)?,
+			len: *stack.peek(1)?,
 		}),
 
 		Opcode::CODECOPY | Opcode::CALLDATACOPY | Opcode::RETURNDATACOPY => Some(MemoryCost {
-			offset: stack.peek(0)?,
-			len: stack.peek(2)?,
+			offset: *stack.peek(0)?,
+			len: *stack.peek(2)?,
 		}),
 
 		Opcode::EXTCODECOPY => Some(MemoryCost {
-			offset: stack.peek(1)?,
-			len: stack.peek(3)?,
+			offset: *stack.peek(1)?,
+			len: *stack.peek(3)?,
 		}),
 
 		Opcode::MLOAD | Opcode::MSTORE => Some(MemoryCost {
-			offset: stack.peek(0)?,
+			offset: *stack.peek(0)?,
 			len: U256::from(32),
 		}),
 
 		Opcode::MSTORE8 => Some(MemoryCost {
-			offset: stack.peek(0)?,
+			offset: *stack.peek(0)?,
 			len: U256::from(1),
 		}),
 
 		Opcode::CREATE | Opcode::CREATE2 => Some(MemoryCost {
-			offset: stack.peek(1)?,
-			len: stack.peek(2)?,
+			offset: *stack.peek(1)?,
+			len: *stack.peek(2)?,
 		}),
 
 		Opcode::CALL | Opcode::CALLCODE => Some(
 			MemoryCost {
-				offset: stack.peek(3)?,
-				len: stack.peek(4)?,
+				offset: *stack.peek(3)?,
+				len: *stack.peek(4)?,
 			}
 			.join(MemoryCost {
-				offset: stack.peek(5)?,
-				len: stack.peek(6)?,
+				offset: *stack.peek(5)?,
+				len: *stack.peek(6)?,
 			}),
 		),
 
 		Opcode::DELEGATECALL | Opcode::STATICCALL => Some(
 			MemoryCost {
-				offset: stack.peek(2)?,
-				len: stack.peek(3)?,
+				offset: *stack.peek(2)?,
+				len: *stack.peek(3)?,
 			}
 			.join(MemoryCost {
-				offset: stack.peek(4)?,
-				len: stack.peek(5)?,
+				offset: *stack.peek(4)?,
+				len: *stack.peek(5)?,
 			}),
 		),
 


### PR DESCRIPTION
Modifies `Stack::peek()` to return a reference, i.e. `&U256` instead of `U256`.
Since `U256` derives `Copy`, call sites which need to own to the value returned
by `peek` may dereference to create a copy:

```rust
let x = *stack.peek(n);
```

Regarding `Stack::peek_h256()`: I _think_ the `H256` value must be constructed
inside the function and since it's not possible to return a reference to a local
variable, `peek_h256` cannot return a reference `&H256`. If I'm missing
something here, please let me know!

The steps mentioned [here under `Reproduction`](https://github.com/aurora-is-near/sputnikvm/pull/11) can be taken to benchmark
this change in `aurora-engine`.

Ref: [#448](https://github.com/aurora-is-near/aurora-engine/issues/448)
