### PR TITLE
perf: store code in `Bytes`

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["no_std", "ethereum"]
 edition = "2018"
 
 [dependencies]
+bytes = { version = "1", default-features = false }
 primitive-types = { version = "0.10", default-features = false }
 codec = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive", "full"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -24,6 +24,7 @@ pub use crate::valids::Valids;
 use crate::eval::{eval, Control};
 use alloc::rc::Rc;
 use alloc::vec::Vec;
+use bytes::Bytes;
 use core::ops::Range;
 use primitive_types::{H160, U256};
 
@@ -32,7 +33,7 @@ pub struct Machine {
 	/// Program data.
 	data: Rc<Vec<u8>>,
 	/// Program code.
-	code: Rc<Vec<u8>>,
+	code: Bytes,
 	/// Program counter.
 	position: Result<usize, ExitReason>,
 	/// Return value.
@@ -86,12 +87,7 @@ impl Machine {
 	}
 
 	/// Create a new machine with given code and data.
-	pub fn new(
-		code: Rc<Vec<u8>>,
-		data: Rc<Vec<u8>>,
-		stack_limit: usize,
-		memory_limit: usize,
-	) -> Self {
+	pub fn new(code: Bytes, data: Rc<Vec<u8>>, stack_limit: usize, memory_limit: usize) -> Self {
 		let valids = Valids::new(&code[..]);
 
 		Self {

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["no_std", "ethereum"]
 edition = "2018"
 
 [dependencies]
+bytes = { version = "1", default-features = false }
 evm-core = { version = "0.33", path = "../core", default-features = false }
 primitive-types = { version = "0.10", default-features = false }
 sha3 = { version = "0.8", default-features = false }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -35,6 +35,7 @@ pub use crate::interrupt::{Resolve, ResolveCall, ResolveCreate};
 
 use alloc::rc::Rc;
 use alloc::vec::Vec;
+use bytes::Bytes;
 
 macro_rules! step {
 	( $self:expr, $handler:expr, $return:tt $($err:path)?; $($ok:path)? ) => ({
@@ -84,12 +85,7 @@ pub struct Runtime<'config> {
 
 impl<'config> Runtime<'config> {
 	/// Create a new runtime with given code and data.
-	pub fn new(
-		code: Rc<Vec<u8>>,
-		data: Rc<Vec<u8>>,
-		context: Context,
-		config: &'config Config,
-	) -> Self {
+	pub fn new(code: Bytes, data: Rc<Vec<u8>>, context: Context, config: &'config Config) -> Self {
 		Self {
 			machine: Machine::new(code, data, config.stack_limit, config.memory_limit),
 			status: Ok(()),

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -703,12 +703,7 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 			self.state.inc_nonce(address);
 		}
 
-		let mut runtime = Runtime::new(
-			Rc::new(init_code),
-			Rc::new(Vec::new()),
-			context,
-			self.config,
-		);
+		let mut runtime = Runtime::new(init_code.into(), Rc::new(Vec::new()), context, self.config);
 
 		let reason = self.execute(&mut runtime);
 		log::debug!(target: "evm", "Create execution using address {}: {:?}", address, reason);
@@ -905,7 +900,7 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 			};
 		}
 
-		let mut runtime = Runtime::new(Rc::new(code), Rc::new(input), context, self.config);
+		let mut runtime = Runtime::new(code.into(), Rc::new(input), context, self.config);
 
 		let reason = self.execute(&mut runtime);
 		log::debug!(target: "evm", "Call execution using address {}: {:?}", code_address, reason);


### PR DESCRIPTION
In [#448](https://github.com/aurora-is-near/aurora-engine/issues/448) it is pointed out that storing code in `Bytes` rather than `Rc<Vec<u8>>` avoids an extra indirection in opcode fetch. This change is implemented in this PR.

## Public interfaces
`Machine::new()` and `Runtime::new()` are changed to have parameter `code: Bytes` instead of `code: Rc<Vec<u8>>`. Without this change, NEAR gas usage increases as constructing `Bytes` then would require cloning the `Vec` inside the `Rc`. (See numbers below.)

While this doesn't break `aurora-engine`, it might break other things. For example, [`jsontests`](https://github.com/rust-blockchain/evm-tests/tree/master/jsontests) would require an update to run on this fork.

## NEAR gas usage
Including this change in `aurora-engine` leads to test failures due to NEAR gas usage which is _lower_ than expected:

```
---- tests::repro::repro_8ru7VEA stdout ----
thread 'tests::repro::repro_8ru7VEA' panicked at 'assertion failed: `(left == right)`
  left: `242`,
 right: `241`', engine-tests/src/tests/repro.rs:146:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- tests::repro::repro_D98vwmi stdout ----
thread 'tests::repro::repro_D98vwmi' panicked at 'assertion failed: `(left == right)`
  left: `199`,
 right: `198`', engine-tests/src/tests/repro.rs:146:5

---- tests::repro::repro_5bEgfRQ stdout ----
thread 'tests::repro::repro_5bEgfRQ' panicked at 'assertion failed: `(left == right)`
  left: `706`,
 right: `705`', engine-tests/src/tests/repro.rs:146:5

---- tests::repro::repro_GdASJ3KESs stdout ----
thread 'tests::repro::repro_GdASJ3KESs' panicked at 'assertion failed: `(left == right)`
  left: `133`,
 right: `132`', engine-tests/src/tests/repro.rs:146:5

---- tests::uniswap::test_uniswap_input_multihop stdout ----
thread 'tests::uniswap::test_uniswap_input_multihop' panicked at 'assertion failed: `(left == right)`
  left: `123`,
 right: `122`', engine-tests/src/tests/uniswap.rs:41:5
```

<details>

<summary>NEAR gas usage if public interface are not changed and instead `Vec<u8>` is cloned:</summary>

<br>

```
---- tests::repro::repro_8ru7VEA stdout ----
thread 'tests::repro::repro_8ru7VEA' panicked at 'assertion failed: `(left == right)`
  left: `242`,
 right: `247`', engine-tests/src/tests/repro.rs:146:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- tests::repro::repro_D98vwmi stdout ----
thread 'tests::repro::repro_D98vwmi' panicked at 'assertion failed: `(left == right)`
  left: `199`,
 right: `205`', engine-tests/src/tests/repro.rs:146:5

---- tests::repro::repro_5bEgfRQ stdout ----
thread 'tests::repro::repro_5bEgfRQ' panicked at 'assertion failed: `(left == right)`
  left: `706`,
 right: `705`', engine-tests/src/tests/repro.rs:146:5

---- tests::repro::repro_FRcorNv stdout ----
thread 'tests::repro::repro_FRcorNv' panicked at 'assertion failed: `(left == right)`
  left: `197`,
 right: `202`', engine-tests/src/tests/repro.rs:146:5

---- tests::repro::repro_GdASJ3KESs stdout ----
thread 'tests::repro::repro_GdASJ3KESs' panicked at 'assertion failed: `(left == right)`
  left: `133`,
 right: `136`', engine-tests/src/tests/repro.rs:146:5

---- tests::uniswap::test_uniswap_exact_output stdout ----
thread 'tests::uniswap::test_uniswap_exact_output' panicked at '34 Tgas is not equal to 33 Tgas', engine-tests/src/test_utils/mod.rs:842:5

---- tests::uniswap::test_uniswap_input_multihop stdout ----
thread 'tests::uniswap::test_uniswap_input_multihop' panicked at 'assertion failed: `(left == right)`
  left: `123`,
 right: `125`', engine-tests/src/tests/uniswap.rs:41:5

---- tests::one_inch::test_1inch_liquidity_protocol stdout ----
thread 'tests::one_inch::test_1inch_liquidity_protocol' panicked at '26 Tgas is not equal to 25 Tgas', engine-tests/src/test_utils/mod.rs:842:5
```
</details>

## Question
Does this change make sense given that it requires breaking public interfaces for rather small improvements in NEAR gas usage?
