### PR TITLE
perf: use `ArrayVec` for `Stack`

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["no_std", "ethereum"]
 edition = "2018"
 
 [dependencies]
+arrayvec = { version = "0.7", default-features = false }
 primitive-types = { version = "0.10", default-features = false }
 codec = { package = "parity-scale-codec", version = "2.0", default-features = false, features = ["derive", "full"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }

--- a/core/src/stack.rs
+++ b/core/src/stack.rs
@@ -1,11 +1,14 @@
 use crate::ExitError;
-use alloc::vec::Vec;
+use arrayvec::ArrayVec;
 use primitive_types::{H256, U256};
+
+// https://ethereum.org/en/developers/docs/evm/#evm-instructions
+const STACK_SIZE: usize = 1024;
 
 /// EVM stack.
 #[derive(Clone, Debug)]
 pub struct Stack {
-	data: Vec<U256>,
+	data: ArrayVec<U256, STACK_SIZE>,
 	limit: usize,
 }
 
@@ -13,7 +16,7 @@ impl Stack {
 	/// Create a new stack with given limit.
 	pub fn new(limit: usize) -> Self {
 		Self {
-			data: Vec::new(),
+			data: ArrayVec::new(),
 			limit,
 		}
 	}
@@ -38,8 +41,8 @@ impl Stack {
 
 	#[inline]
 	/// Stack data.
-	pub fn data(&self) -> &Vec<U256> {
-		&self.data
+	pub fn data(&self) -> &[U256] {
+		self.data.as_ref()
 	}
 
 	#[inline]


### PR DESCRIPTION
Changes the type of field `Stack.data` from `Vec<U256>` to `ArrayVec<U256, 1024>`.
This optimization was proposed in [#448](https://github.com/aurora-is-near/aurora-engine/issues/448) and is based on the limit of 1024
items for the [EVM stack](https://ethereum.org/en/developers/docs/evm/#evm-instructions).

## Change of a public interface
`Stack::data()` returns `&[U256]` instead of `&Vec<U256>`.

## NEAR gas usage
There a few tests in `aurora-engine` which fail due to gas usage _lower_ than
expected:

```
---- tests::repro::repro_8ru7VEA stdout ----
thread 'tests::repro::repro_8ru7VEA' panicked at 'assertion failed: `(left == right)`
  left: `242`,
 right: `240`', engine-tests/src/tests/repro.rs:146:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- tests::repro::repro_D98vwmi stdout ----
thread 'tests::repro::repro_D98vwmi' panicked at 'assertion failed: `(left == right)`
  left: `199`,
 right: `198`', engine-tests/src/tests/repro.rs:146:5

---- tests::repro::repro_5bEgfRQ stdout ----
thread 'tests::repro::repro_5bEgfRQ' panicked at 'assertion failed: `(left == right)`
  left: `706`,
 right: `705`', engine-tests/src/tests/repro.rs:146:5

---- tests::repro::repro_FRcorNv stdout ----
thread 'tests::repro::repro_FRcorNv' panicked at 'assertion failed: `(left == right)`
  left: `197`,
 right: `196`', engine-tests/src/tests/repro.rs:146:5

---- tests::repro::repro_GdASJ3KESs stdout ----
thread 'tests::repro::repro_GdASJ3KESs' panicked at 'assertion failed: `(left == right)`
  left: `133`,
 right: `132`', engine-tests/src/tests/repro.rs:146:5

---- tests::uniswap::test_uniswap_input_multihop stdout ----
thread 'tests::uniswap::test_uniswap_input_multihop' panicked at 'assertion failed: `(left == right)`
  left: `123`,
 right: `122`', engine-tests/src/tests/uniswap.rs:41:5
```

## Issue with `jsontests`
This change causes a stack overflow in [`evm-tests/jsontests`](https://github.com/rust-blockchain/evm-tests/tree/master/jsontests). Identifying
the cause of a stack overflow in Rust [can be tricky](
https://users.rust-lang.org/t/how-to-diagnose-a-stack-overflow-issues-cause/17320). Therefore, before
trying to get to the bottom of this, it might make sense to evaluate if this
change could/would be merged at all?

Note: It seems like the latest `jsontests` commit suitable for Aurora's EVM fork
is [`c66b562`](https://github.com/rust-blockchain/evm-tests/tree/c66b562d3063a86054159febff3507c772e246d7).