### PR TITLE
Fix: add missing trace event

### DIFF
--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -494,6 +494,7 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 				}
 				RuntimeKind::Execute => (reason, None, runtime.inner.machine().return_value()),
 			};
+			emit_exit!(&reason, &return_data);
 			// We're done with that runtime now, so can pop it off the call stack
 			call_stack.pop();
 			// Now pass the results from that runtime on to the next one in the stack


### PR DESCRIPTION
Now sputnikvm is using explicit EVM call stack, but it seems like the `emit_exit!` is missing for the nested calls/creates. [L1377](https://github.com/aurora-is-near/sputnikvm/blob/v0.37.2-aurora/src/executor/stack/executor.rs#L1377) and [L13277](https://github.com/aurora-is-near/sputnikvm/blob/v0.37.2-aurora/src/executor/stack/executor.rs#L1327) are no longer useful most of the time, because they are now executed in `execute_with_call_stack`. So I think the `emit_exit!` can be inserted here for tracing.