### PR TITLE
Fix(tracing): include missing Exit events

### DIFF
--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -501,6 +501,7 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 				Some(r) => r,
 				None => return (reason, None, return_data),
 			};
+			emit_exit!(&reason, &return_data);
 			let inner_runtime = &mut runtime.inner;
 			let maybe_error = match runtime_kind {
 				RuntimeKind::Create(_) => {
@@ -1461,7 +1462,7 @@ impl<'inner, 'config, 'precompiles, S: StackState<'config>, P: PrecompileSet> Pr
 				call_stack.push(rt.0);
 				let (reason, _, return_data) =
 					self.executor.execute_with_call_stack(&mut call_stack);
-				(reason, return_data)
+				emit_exit!(reason, return_data)
 			}
 		}
 	}

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -1000,7 +1000,8 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 		return_data: Vec<u8>,
 	) -> (ExitReason, Option<H160>, Vec<u8>) {
 		fn check_first_byte(config: &Config, code: &[u8]) -> Result<(), ExitError> {
-			if config.disallow_executable_format && Some(&Opcode::EOFMAGIC.as_u8()) == code.get(0) {
+			if config.disallow_executable_format && Some(&Opcode::EOFMAGIC.as_u8()) == code.first()
+			{
 				return Err(ExitError::InvalidCode(Opcode::EOFMAGIC));
 			}
 			Ok(())
@@ -1419,7 +1420,7 @@ impl<'inner, 'config, 'precompiles, S: StackState<'config>, P: PrecompileSet> Pr
 		// We record the length of the input.
 		let memory_cost = Some(crate::gasometer::MemoryCost {
 			offset: 0,
-			len: input.len().into(),
+			len: input.len(),
 		});
 
 		if let Err(error) = self


### PR DESCRIPTION
The move to an explicit stack for EVM calls resulted in some of the tracing events not being emitted. This PR fixes the issue. Thanks to @last-las for bringing this issue to our attention!

At the same time I'm also fixing a couple little clippy warnings.