### PR TITLE
Feat(tracing): trace code stored as a result of create

### DIFF
--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -1036,6 +1036,10 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 				{
 					Ok(()) => {
 						let exit_result = self.exit_substate(StackExitKind::Succeeded);
+						event!(CreateOutput {
+							address,
+							code: &out,
+						});
 						self.state.set_code(address, out);
 						if let Err(e) = exit_result {
 							return (e.into(), None, Vec::new());

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -33,6 +33,10 @@ pub enum Event<'a> {
 		target: H160,
 		balance: U256,
 	},
+	CreateOutput {
+		address: H160,
+		code: &'a [u8],
+	},
 	Exit {
 		reason: &'a ExitReason,
 		return_value: &'a [u8],


### PR DESCRIPTION
Currently in SputnikVM there is no way within the tracing mechanism to see what code was generated from a contract deploy. However, this functionality is necessary to fill in the `code` field in some tracing outputs (see https://docs.alchemy.com/reference/what-are-evm-traces#create ). In this PR I add a new event variant to capture the code stored when create executions happen.