### PR TITLE
fix: handle panic in converting too big u256 to usize

### DIFF
--- a/core/src/eval/macros.rs
+++ b/core/src/eval/macros.rs
@@ -63,7 +63,12 @@ macro_rules! pop_usize {
 	( $machine:expr, $( $x:ident ),* ) => (
 		$(
 			let $x = match $machine.stack.pop() {
-				Ok(value) => value.as_usize(),
+				Ok(value) if value <= usize::MAX.into() => value.as_usize(),
+				Ok(_) => return Control::Exit(crate::ExitReason::Fatal(
+					crate::ExitFatal::Other(
+						std::borrow::Cow::Borrowed("Number is bigger then usize::MAX"))
+					)
+				),
 				Err(e) => return Control::Exit(e.into()),
 			};
 		)*

--- a/runtime/src/eval/macros.rs
+++ b/runtime/src/eval/macros.rs
@@ -63,7 +63,12 @@ macro_rules! pop_usize {
 	( $machine:expr, $( $x:ident ),* ) => (
 		$(
 			let $x = match $machine.machine.stack_mut().pop() {
-				Ok(value) => value.as_usize(),
+				Ok(value) if value <= usize::MAX.into() => value.as_usize(),
+				Ok(_) => return Control::Exit(crate::ExitReason::Fatal(
+					crate::ExitFatal::Other(
+						std::borrow::Cow::Borrowed("Number is bigger then usize::MAX"))
+					)
+				),
 				Err(e) => return Control::Exit(e.into()),
 			};
 		)*

--- a/runtime/src/eval/system.rs
+++ b/runtime/src/eval/system.rs
@@ -7,14 +7,10 @@ use primitive_types::{H256, U256};
 use sha3::{Digest, Keccak256};
 
 pub fn sha3<H: Handler>(runtime: &mut Runtime) -> Control<H> {
-	pop_u256!(runtime, from);
+	pop_usize!(runtime, from);
 	pop_usize!(runtime, len);
 
-	let from = if len == 0 {
-		usize::MAX
-	} else {
-		from.as_usize()
-	};
+	let from = if len == 0 { usize::MAX } else { from };
 
 	try_or_fail!(runtime.machine.memory_mut().resize_offset(from, len));
 	let data = if len == 0 {
@@ -248,14 +244,10 @@ pub fn gas<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 }
 
 pub fn log<H: Handler>(runtime: &mut Runtime, n: u8, handler: &mut H) -> Control<H> {
-	pop_u256!(runtime, offset);
+	pop_usize!(runtime, offset);
 	pop_usize!(runtime, len);
 
-	let offset = if len == 0 {
-		usize::MAX
-	} else {
-		offset.as_usize()
-	};
+	let offset = if len == 0 { usize::MAX } else { offset };
 
 	try_or_fail!(runtime.machine.memory_mut().resize_offset(offset, len));
 	let data = if len == 0 {


### PR DESCRIPTION
Added a check that the received `U256` value from the stack is smaller or equal to `usize::MAX` before converting to `usize`. Because in case of the converting bigger value, we get panic.