### PR TITLE
Fix(returndatacopy): Data offset out of bounds is still an error even if len==0

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -115,7 +115,9 @@ impl Machine {
 	/// Inspect the machine's next opcode and current stack.
 	#[must_use]
 	pub fn inspect(&self) -> Option<(Opcode, &Stack)> {
-		let Ok(position) = self.position else { return None };
+		let Ok(position) = self.position else {
+			return None;
+		};
 		self.code.get(position).map(|v| (Opcode(*v), &self.stack))
 	}
 

--- a/runtime/src/eval/system.rs
+++ b/runtime/src/eval/system.rs
@@ -148,18 +148,20 @@ pub fn returndatacopy<H: Handler>(runtime: &mut Runtime) -> Control<H> {
 	pop_u256!(runtime, data_offset);
 	pop_usize!(runtime, len);
 
-	// If `len` is zero then nothing happens, regardless of the
-	// value of the other parameters. In particular, `memory_offset`
-	// might be larger than `usize::MAX`, hence why we check this first.
-	if len == 0 {
-		return Control::Continue;
-	}
-
-	// SAFETY: this cast is safe because if `len > 0` then gas cost of memory
-	// would have already been taken into account at this point. It is impossible
-	// to have a memory offset greater than `usize::MAX` for any gas limit less
-	// than `u64::MAX` (and gas limits higher than this are disallowed in general).
-	let memory_offset = memory_offset.as_usize();
+	// If `len` is zero then nothing happens to the memory, regardless
+	// of the value of `memory_offset`. In particular, the value taken
+	// from the stack might be larger than `usize::MAX`, hence why the
+	// `as_usize` cast is not always safe. But because the value does
+	// not matter when `len == 0` we can safely set it equal to zero instead.
+	let memory_offset = if len == 0 {
+		0
+	} else {
+		// SAFETY: this cast is safe because if `len > 0` then gas cost of memory
+		// would have already been taken into account at this point. It is impossible
+		// to have a memory offset greater than `usize::MAX` for any gas limit less
+		// than `u64::MAX` (and gas limits higher than this are disallowed in general).
+		memory_offset.as_usize()
+	};
 
 	try_or_fail!(runtime
 		.machine

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.68.2"
+channel = "1.72.1"
 profile = "minimal"
 components = [ "rustfmt", "clippy" ]


### PR DESCRIPTION
I made a mistake in #26 by adding the early return when `len == 0`. The function is still supposed to return an error if the `data_offset` is out of bounds even if when `len` is zero. This was causing a failure in the `st_memory` EVM test.

I have modified the logic to simply assign `memory_offset` as 0 if `len == 0` instead of existing the function early. This assignment is safe because `memory_offset` is not actually used in any of the memory-related functions in the case `len` is zero.

All the EVM tests now once again pass.