### PR TITLE
fix: use full path to vec macro

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,6 +23,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --verbose
+    - name: Build NoStd
+      run: cargo build --no-default-features --verbose
     - name: Build for feature (tracing)
       run: cargo build --features tracing --verbose
     - name: Run tests

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evm-core"
-version = "0.39.0"
+version = "0.39.1"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>", "Parity Technologies <admin@parity.io>"]
 description = "Portable Ethereum Virtual Machine implementation written in pure Rust."

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -127,7 +127,7 @@ impl Machine {
 	#[must_use]
 	pub fn return_value(&self) -> Vec<u8> {
 		if self.return_range.start > U256::from(usize::MAX) {
-			vec![0; (self.return_range.end - self.return_range.start).as_usize()]
+			alloc::vec![0; (self.return_range.end - self.return_range.start).as_usize()]
 		} else if self.return_range.end > U256::from(usize::MAX) {
 			let mut ret = self.memory.get(
 				self.return_range.start.as_usize(),

--- a/gasometer/Cargo.toml
+++ b/gasometer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evm-gasometer"
-version = "0.39.0"
+version = "0.39.1"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>", "Parity Technologies <admin@parity.io>"]
 description = "Portable Ethereum Virtual Machine implementation written in pure Rust."

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evm-runtime"
-version = "0.39.0"
+version = "0.39.1"
 license = "Apache-2.0"
 authors = ["Wei Tang <hi@that.world>", "Parity Technologies <admin@parity.io>"]
 description = "SputnikVM - a Portable Blockchain Virtual Machine"


### PR DESCRIPTION
The PR fixes compile error with the `no_std` feature.