### PR TITLE
Feat: add optimizations for U256 constant calculations and Backend operations

### DIFF
--- a/core/src/eval/misc.rs
+++ b/core/src/eval/misc.rs
@@ -1,4 +1,5 @@
 use super::Control;
+use crate::utils::USIZE_MAX;
 use crate::{ExitError, ExitRevert, ExitSucceed, Machine};
 use core::cmp::min;
 use primitive_types::{H256, U256};
@@ -43,7 +44,7 @@ pub fn calldataload(state: &mut Machine) -> Control {
 	#[allow(clippy::needless_range_loop)]
 	for i in 0..32 {
 		if let Some(p) = index.checked_add(U256::from(i)) {
-			if p <= U256::from(usize::MAX) {
+			if p <= USIZE_MAX {
 				let p = p.as_usize();
 				if p < state.data.len() {
 					load[i] = state.data[p];

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -34,6 +34,7 @@ pub use crate::valids::Valids;
 
 use crate::eval::{eval, Control};
 use crate::prelude::*;
+use crate::utils::USIZE_MAX;
 use core::ops::Range;
 use primitive_types::{H160, U256};
 
@@ -135,9 +136,9 @@ impl Machine {
 	/// Copy and get the return value of the machine, if any.
 	#[must_use]
 	pub fn return_value(&self) -> Vec<u8> {
-		if self.return_range.start > U256::from(usize::MAX) {
+		if self.return_range.start > USIZE_MAX {
 			vec![0; (self.return_range.end - self.return_range.start).as_usize()]
-		} else if self.return_range.end > U256::from(usize::MAX) {
+		} else if self.return_range.end > USIZE_MAX {
 			let mut ret = self.memory.get(
 				self.return_range.start.as_usize(),
 				usize::MAX - self.return_range.start.as_usize(),

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use crate::utils::USIZE_MAX;
 use crate::{ExitError, ExitFatal};
 use core::cmp::min;
 use core::ops::{BitAnd, Not};
@@ -204,7 +205,7 @@ impl Memory {
 		let data = data_offset
 			.checked_add(len.into())
 			.map_or(&[] as &[u8], |end| {
-				if end > U256::from(usize::MAX) {
+				if end > USIZE_MAX {
 					&[]
 				} else {
 					let data_offset = data_offset.as_usize();

--- a/core/src/stack.rs
+++ b/core/src/stack.rs
@@ -1,4 +1,5 @@
 use crate::prelude::*;
+use crate::utils::USIZE_MAX;
 use crate::ExitError;
 use primitive_types::{H256, U256};
 
@@ -104,7 +105,7 @@ impl Stack {
 	/// If the value is larger than `usize::MAX`, `OutOfGas` error is returned.
 	pub fn peek_usize(&self, no_from_top: usize) -> Result<usize, ExitError> {
 		let u = self.peek(no_from_top)?;
-		if u > usize::MAX.into() {
+		if u > USIZE_MAX {
 			return Err(ExitError::OutOfGas);
 		}
 		Ok(u.as_usize())

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -4,6 +4,8 @@ use primitive_types::U256;
 
 /// Precalculated `usize::MAX` for `U256`
 pub const USIZE_MAX: U256 = U256([usize::MAX as u64, 0, 0, 0]);
+/// Precalculated `u64::MAX` for `U256`
+pub const U64_MAX: U256 = U256([u64::MAX, 0, 0, 0]);
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum Sign {

--- a/evm-tests/jsontests/src/state.rs
+++ b/evm-tests/jsontests/src/state.rs
@@ -10,6 +10,7 @@ use evm::executor::stack::{
 	MemoryStackState, PrecompileFailure, PrecompileFn, PrecompileOutput, StackExecutor,
 	StackSubstateMetadata,
 };
+use evm::utils::U64_MAX;
 use evm::{Config, Context, ExitError, ExitReason, ExitSucceed};
 use lazy_static::lazy_static;
 use libsecp256k1::SecretKey;
@@ -239,7 +240,7 @@ impl JsonPrecompile {
 		let cost = builtin.cost(input, 0);
 
 		if let Some(target_gas) = gas_limit {
-			if cost > U256::from(u64::MAX) || target_gas < cost.as_u64() {
+			if cost > U64_MAX || target_gas < cost.as_u64() {
 				return Err(PrecompileFailure::Error {
 					exit_status: ExitError::OutOfGas,
 				});

--- a/gasometer/src/costs.rs
+++ b/gasometer/src/costs.rs
@@ -1,5 +1,6 @@
 use crate::consts::*;
 use crate::Config;
+use evm_core::utils::U64_MAX;
 use evm_core::ExitError;
 use primitive_types::{H256, U256};
 
@@ -72,7 +73,7 @@ pub fn create2_cost(len: U256) -> Result<u64, ExitError> {
 		.ok_or(ExitError::OutOfGas)?;
 	let gas = base.checked_add(sha_addup).ok_or(ExitError::OutOfGas)?;
 
-	if gas > U256::from(u64::MAX) {
+	if gas > U64_MAX {
 		return Err(ExitError::OutOfGas);
 	}
 
@@ -91,7 +92,7 @@ pub fn exp_cost(power: U256, config: &Config) -> Result<u64, ExitError> {
 			)
 			.ok_or(ExitError::OutOfGas)?;
 
-		if gas > U256::from(u64::MAX) {
+		if gas > U64_MAX {
 			return Err(ExitError::OutOfGas);
 		}
 
@@ -115,7 +116,7 @@ pub fn verylowcopy_cost(len: U256) -> Result<u64, ExitError> {
 		)
 		.ok_or(ExitError::OutOfGas)?;
 
-	if gas > U256::from(u64::MAX) {
+	if gas > U64_MAX {
 		return Err(ExitError::OutOfGas);
 	}
 
@@ -137,7 +138,7 @@ pub fn extcodecopy_cost(len: U256, is_cold: bool, config: &Config) -> Result<u64
 		)
 		.ok_or(ExitError::OutOfGas)?;
 
-	if gas > U256::from(u64::MAX) {
+	if gas > U64_MAX {
 		return Err(ExitError::OutOfGas);
 	}
 
@@ -155,7 +156,7 @@ pub fn log_cost(n: u8, len: U256) -> Result<u64, ExitError> {
 		.checked_add(U256::from(G_LOGTOPIC * n as u32))
 		.ok_or(ExitError::OutOfGas)?;
 
-	if gas > U256::from(u64::MAX) {
+	if gas > U64_MAX {
 		return Err(ExitError::OutOfGas);
 	}
 
@@ -178,7 +179,7 @@ pub fn sha3_cost(len: U256) -> Result<u64, ExitError> {
 		)
 		.ok_or(ExitError::OutOfGas)?;
 
-	if gas > U256::from(u64::MAX) {
+	if gas > U64_MAX {
 		return Err(ExitError::OutOfGas);
 	}
 

--- a/runtime/src/eval/system.rs
+++ b/runtime/src/eval/system.rs
@@ -4,6 +4,7 @@ use crate::{
 	CallScheme, Capture, Context, CreateScheme, ExitError, ExitSucceed, Handler, Runtime, Transfer,
 };
 use core::cmp::max;
+use evm_core::utils::U64_MAX;
 use primitive_types::{H256, U256};
 use sha3::{Digest, Keccak256};
 
@@ -466,7 +467,7 @@ pub fn call<H: Handler>(runtime: &mut Runtime, scheme: CallScheme, handler: &mut
 
 	pop_u256!(runtime, gas);
 	pop_h256!(runtime, to);
-	let gas = if gas > U256::from(u64::MAX) {
+	let gas = if gas > U64_MAX {
 		None
 	} else {
 		Some(gas.as_u64())

--- a/runtime/src/eval/system.rs
+++ b/runtime/src/eval/system.rs
@@ -4,7 +4,7 @@ use crate::{
 	CallScheme, Capture, Context, CreateScheme, ExitError, ExitSucceed, Handler, Runtime, Transfer,
 };
 use core::cmp::max;
-use evm_core::utils::U64_MAX;
+use evm_core::utils::{U64_MAX, USIZE_MAX};
 use primitive_types::{H256, U256};
 use sha3::{Digest, Keccak256};
 
@@ -112,7 +112,7 @@ pub fn blob_hash<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 		Err(e) => return Control::Exit(e.into()),
 	};
 	// Safely cast to usize
-	let index = if raw_index > usize::MAX.into() {
+	let index = if raw_index > USIZE_MAX {
 		usize::MAX
 	} else {
 		raw_index.as_usize()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,10 +15,12 @@ pub mod prelude {
 		rc::Rc,
 		vec::Vec,
 	};
+	pub use core::cell::RefCell;
 }
 #[cfg(feature = "std")]
 pub mod prelude {
 	pub use std::{
+		cell::RefCell,
 		collections::{BTreeMap, BTreeSet},
 		rc::Rc,
 		vec::Vec,


### PR DESCRIPTION
## Description

Added optimizations:
➡️  constants for `U256`: `U64_MAX`, `USIZE_MAX`

### MemoryStack optimizations

If was added cache for `Backend` operations.
➡️  added cache for operations with `Backend` trait for `MemoryStack`

But as result of testings for `aurora-engine` gas cost insignificantly increased (about `0.5%`) for 1 tests. And it was not gas decreased. So it was finally removed.