### PR TITLE
Feat: ethereum tests v14.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           repository: ethereum/tests
           path: ethtests
-          ref: v14
+          ref: v14.0
           submodules: recursive
           fetch-depth: 1
 
@@ -59,6 +59,7 @@ jobs:
           cargo run -r -p evm-jsontests -F enable-slow-tests -- \
           	state -f \
           	ethtests/GeneralStateTests/ \
+            ethtests/LegacyTests/Cancun/GeneralStateTests/ \
             ethtests/EIPTests/StateTests/
 
       - name: Run Ethereum vm tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           repository: ethereum/tests
           path: ethtests
-          ref: v13.3
+          ref: v14
           submodules: recursive
           fetch-depth: 1
 
@@ -58,7 +58,8 @@ jobs:
         run: |
           cargo run -r -p evm-jsontests -F enable-slow-tests -- \
           	state -f \
-          	ethtests/GeneralStateTests/
+          	ethtests/GeneralStateTests/ \
+            ethtests/EIPTests/StateTests/
 
       - name: Run Ethereum vm tests
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ keywords.workspace = true
 edition.workspace = true
 
 [workspace.dependencies]
-evm = { version = "0.43", path = "." }
-evm-core = { version = "0.43", path = "core", default-features = false }
-evm-gasometer = { version = "0.43", path = "gasometer", default-features = false }
-evm-runtime = { version = "0.43", path = "runtime", default-features = false }
+evm = { version = "0.44.1", path = "." }
+evm-core = { version = "0.44.1", path = "core", default-features = false }
+evm-gasometer = { version = "0.44.1", path = "gasometer", default-features = false }
+evm-runtime = { version = "0.44.1", path = "runtime", default-features = false }
 primitive-types = { version = "0.12", default-features = false }
 auto_impl = "1.0"
 sha3 = { version = "0.10", default-features = false }
@@ -87,7 +87,7 @@ create-fixed = []
 print-debug = ["evm-gasometer/print-debug"]
 
 [workspace.package]
-version = "0.43.0"
+version = "0.44.1"
 license = "Apache-2.0"
 authors = ["Aurora Labs <hello@aurora.dev>", "Wei Tang <hi@that.world>", "Parity Technologies <admin@parity.io>"]
 description = "Portable Ethereum Virtual Machine implementation written in pure Rust."

--- a/evm-tests/ethjson/src/spec/spec.rs
+++ b/evm-tests/ethjson/src/spec/spec.rs
@@ -66,6 +66,8 @@ pub enum ForkSpec {
 	Shanghai,
 	/// Cancun (2024-03-13)
 	Cancun,
+	/// Prague-Electra—aka Pectra
+	Prague,
 }
 
 impl ForkSpec {

--- a/evm-tests/jsontests/src/state.rs
+++ b/evm-tests/jsontests/src/state.rs
@@ -665,10 +665,11 @@ fn assert_empty_create_caller(expect_exception: &Option<String>, name: &str) {
 	let exception = expect_exception
 		.as_deref()
 		.expect("expected evm-json-test exception");
-	let check_exception = exception == "SenderNotEOA";
+	let check_exception =
+		exception == "SenderNotEOA" || exception == "TransactionException.SENDER_NOT_EOA";
 	assert!(
 		check_exception,
-		"expected EmptyCaller exception for test: {name}"
+		"expected EmptyCaller exception for test: {name}: {expect_exception:?}"
 	);
 }
 
@@ -700,7 +701,8 @@ fn check_create_exit_reason(
 						return true;
 					}
 					ExitError::MaxNonce => {
-						let check_result = exception == "TR_NonceHasMaxValue";
+						let check_result = exception == "TR_NonceHasMaxValue"
+							|| exception == "TransactionException.NONCE_IS_MAX";
 						assert!(check_result,
 								"unexpected exception {exception:?} for MaxNonce error for test: {name}"
 						);
@@ -743,7 +745,8 @@ fn assert_vicinity_validation(
 						.expect_exception
 						.as_deref()
 						.expect("expected error message for test: [{spec}] {name}:{i}");
-					let is_checked = expected == "TR_TypeNotSupported";
+					let is_checked =
+						expected == "TR_TypeNotSupported" || expected == "TR_TypeNotSupportedBlob";
 					assert!(
 						is_checked,
 						"unexpected error message {expected:?} for: [{spec:?}] {name}:{i}",
@@ -840,36 +843,37 @@ fn assert_vicinity_validation(
 				_ => panic!("Unexpected validation reason: {reason:?} [{spec:?}] {name}"),
 			}
 		}
-		ForkSpec::Cancun => {
-			match reason {
-				InvalidTxReason::PriorityFeeTooLarge => {
-					for (i, state) in states.iter().enumerate() {
-						let expected = state.expect_exception.as_deref().expect(
-							"expected error message for test: {reason:?} [{spec}] {name}:{i}",
-						);
-						let is_checked = expected == "TR_TipGtFeeCap";
-						assert!(
+		ForkSpec::Cancun => match reason {
+			InvalidTxReason::PriorityFeeTooLarge => {
+				for (i, state) in states.iter().enumerate() {
+					let expected = state
+						.expect_exception
+						.as_deref()
+						.expect("expected error message for test: {reason:?} [{spec}] {name}:{i}");
+					let is_checked = expected == "TR_TipGtFeeCap"
+						|| expected == "TransactionException.PRIORITY_GREATER_THAN_MAX_FEE_PER_GAS";
+					assert!(
 							is_checked,
 							"unexpected error message {expected:?} for: {reason:?} [{spec:?}] {name}:{i}",
 						);
-					}
 				}
-				InvalidTxReason::GasPriceLessThenBlockBaseFee => {
-					for (i, state) in states.iter().enumerate() {
-						let expected = state.expect_exception.as_deref().expect(
-							"expected error message for test: {reason:?} [{spec}] {name}:{i}",
-						);
-						let is_checked = expected == "TR_FeeCapLessThanBlocks"
-							|| expected == "TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS";
-						assert!(
-							is_checked,
-							"unexpected error message {expected:?} for: {reason:?} [{spec:?}] {name}:{i}",
-						);
-					}
-				}
-				_ => panic!("Unexpected validation reason: {reason:?} [{spec:?}] {name}"),
 			}
-		}
+			InvalidTxReason::GasPriceLessThenBlockBaseFee => {
+				for (i, state) in states.iter().enumerate() {
+					let expected = state
+						.expect_exception
+						.as_deref()
+						.expect("expected error message for test: {reason:?} [{spec}] {name}:{i}");
+					let is_checked = expected == "TR_FeeCapLessThanBlocks"
+						|| expected == "TransactionException.INSUFFICIENT_MAX_FEE_PER_GAS";
+					assert!(
+							is_checked,
+							"unexpected error message {expected:?} for: {reason:?} [{spec:?}] {name}:{i}",
+						);
+				}
+			}
+			_ => panic!("Unexpected validation reason: {reason:?} [{spec:?}] {name}"),
+		},
 		_ => panic!("Unexpected validation reason: {reason:?} [{spec:?}] {name}"),
 	}
 }
@@ -892,14 +896,16 @@ fn check_validate_exit_reason(
 						== "TransactionException.INSUFFICIENT_ACCOUNT_FUNDS"
 						|| exception == "TR_NoFunds"
 						|| exception == "TR_NoFundsX"
-						|| exception == "TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS";
+						|| exception == "TransactionException.INSUFFICIENT_MAX_FEE_PER_BLOB_GAS"
+						|| exception=="TransactionException.INSUFFICIENT_ACCOUNT_FUNDS|TransactionException.GASLIMIT_PRICE_PRODUCT_OVERFLOW";
 					assert!(
 						check_result,
 						"unexpected exception {exception:?} for OutOfFund for test: [{spec:?}] {name}"
 					);
 				}
 				InvalidTxReason::GasLimitReached => {
-					let check_result = exception == "TR_GasLimitReached";
+					let check_result = exception == "TR_GasLimitReached"
+						|| exception == "TransactionException.GAS_ALLOWANCE_EXCEEDED";
 					assert!(
 						check_result,
 						"unexpected exception {exception:?} for GasLimitReached for test: [{spec:?}] {name}"
@@ -909,7 +915,8 @@ fn check_validate_exit_reason(
 					let check_result = exception == "TR_NoFundsOrGas"
 						|| exception == "TR_IntrinsicGas"
 						|| exception == "TransactionException.INTRINSIC_GAS_TOO_LOW"
-						|| exception == "IntrinsicGas";
+						|| exception == "IntrinsicGas"
+						|| exception == "TransactionException.INSUFFICIENT_ACCOUNT_FUNDS|TransactionException.INTRINSIC_GAS_TOO_LOW";
 					assert!(
 						check_result,
 						"unexpected exception {exception:?} for IntrinsicGas for test: [{spec:?}] {name}"
@@ -925,7 +932,8 @@ fn check_validate_exit_reason(
 					);
 				}
 				InvalidTxReason::BlobCreateTransaction => {
-					let check_result = exception == "TR_BLOBCREATE";
+					let check_result = exception == "TR_BLOBCREATE"
+						|| exception == "TransactionException.TYPE_3_TX_CONTRACT_CREATION";
 					assert!(
 						check_result,
 						"unexpected exception {exception:?} for BlobCreateTransaction for test: [{spec:?}] {name}"
@@ -964,7 +972,8 @@ fn check_validate_exit_reason(
 					);
 				}
 				InvalidTxReason::BlobVersionedHashesNotSupported => {
-					let check_result = exception == "TransactionException.TYPE_3_TX_PRE_FORK";
+					let check_result = exception == "TransactionException.TYPE_3_TX_PRE_FORK"
+						|| exception == "TR_TypeNotSupportedBlob";
 					assert!(
 						check_result,
 						"unexpected exception {exception:?} for BlobVersionedHashesNotSupported for test: [{spec:?}] {name}"


### PR DESCRIPTION
## Description

Switched to [ethereum/tests v14.0](https://github.com/ethereum/tests/releases/tag/v14.0). Main changes: all tests for previous hard forks moved to `LegacyTests/Cancun/GeneralStateTests/`


➡️  Added `Prague` hard fork check for new tests compatibility: `Prague-Electra` (aka `Pectra`) is an upcoming hard fork
➡️  Extended errors message checking
➡️  Added CI tests (as all previous hard forks moved to `LegacyTests`): `LegacyTests/Cancun/GeneralStateTests/`
➡️  Added CI tests: `ethtests/EIPTests/StateTests/`
➡️  Updated CI to `ethereum/tests v14.0`
