### PR TITLE
Chore: Refactore EVM ExitFatal reason

### DIFF
--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -164,6 +164,10 @@ pub enum ExitError {
 	/// https://eips.ethereum.org/EIPS/eip-2681
 	#[cfg_attr(feature = "with-codec", codec(index = 14))]
 	MaxNonce,
+
+	/// `usize` casting overflow
+	#[cfg_attr(feature = "with-codec", codec(index = 15))]
+	UsizeOverflow,
 }
 
 impl From<ExitError> for ExitReason {
@@ -182,8 +186,6 @@ impl From<ExitError> for ExitReason {
 pub enum ExitFatal {
 	/// The operation is not supported.
 	NotSupported,
-	/// `usize` casting overflow
-	UsizeOverflow,
 	/// The trap (interrupt) is unhandled.
 	UnhandledInterrupt,
 	/// The environment explicitly set call errors as fatal error.

--- a/core/src/eval/macros.rs
+++ b/core/src/eval/macros.rs
@@ -134,7 +134,7 @@ macro_rules! op3_u256_fn {
 macro_rules! as_usize_or_fail {
 	( $v:expr ) => {{
 		if $v > crate::utils::USIZE_MAX {
-			return Control::Exit(ExitFatal::UsizeOverflow.into());
+			return Control::Exit(ExitError::UsizeOverflow.into());
 		}
 
 		$v.as_usize()

--- a/core/src/eval/misc.rs
+++ b/core/src/eval/misc.rs
@@ -1,7 +1,7 @@
 use super::Control;
 
 use crate::utils::USIZE_MAX;
-use crate::{ExitError, ExitFatal, ExitRevert, ExitSucceed, Machine};
+use crate::{ExitError, ExitRevert, ExitSucceed, Machine};
 use core::cmp::min;
 use primitive_types::{H256, U256};
 

--- a/runtime/src/eval/macros.rs
+++ b/runtime/src/eval/macros.rs
@@ -58,7 +58,7 @@ macro_rules! push_u256 {
 macro_rules! as_usize_or_fail {
 	( $v:expr ) => {{
 		if $v > crate::utils::USIZE_MAX {
-			return Control::Exit(ExitFatal::UsizeOverflow.into());
+			return Control::Exit(ExitError::UsizeOverflow.into());
 		}
 
 		$v.as_usize()

--- a/runtime/src/eval/system.rs
+++ b/runtime/src/eval/system.rs
@@ -1,8 +1,7 @@
 use super::Control;
 use crate::prelude::*;
 use crate::{
-	CallScheme, Capture, Context, CreateScheme, ExitError, ExitFatal, ExitSucceed, Handler,
-	Runtime, Transfer,
+	CallScheme, Capture, Context, CreateScheme, ExitError, ExitSucceed, Handler, Runtime, Transfer,
 };
 use core::cmp::max;
 use evm_core::utils::{U64_MAX, USIZE_MAX};


### PR DESCRIPTION
## Description

Refactored EVM `ExitFatal` reason for only Fatal `cases`.
:arrow_right: Moved `ExitFatal::UsizeOverflow` to `ExitError::UsizeOverflow` as it's not `Fatal` case for EVM exit.

### Compatability
:arrow_backward:  Please **NOTE** that it can break compatibility, as was changed  EVM `ExitReason`.


