### PR TITLE
Feat: Fix config hard fork functions as const functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ keywords.workspace = true
 edition.workspace = true
 
 [workspace.dependencies]
-evm = { version = "0.45.1", path = "." }
-evm-core = { version = "0.45.1", path = "core", default-features = false }
-evm-gasometer = { version = "0.45.1", path = "gasometer", default-features = false }
-evm-runtime = { version = "0.45.1", path = "runtime", default-features = false }
+evm = { version = "0.45.2", path = "." }
+evm-core = { version = "0.45.2", path = "core", default-features = false }
+evm-gasometer = { version = "0.45.2", path = "gasometer", default-features = false }
+evm-runtime = { version = "0.45.2", path = "runtime", default-features = false }
 primitive-types = { version = "0.12", default-features = false }
 auto_impl = "1.0"
 sha3 = { version = "0.10", default-features = false }
@@ -87,7 +87,7 @@ create-fixed = []
 print-debug = ["evm-gasometer/print-debug"]
 
 [workspace.package]
-version = "0.45.1"
+version = "0.45.2"
 license = "Apache-2.0"
 authors = ["Aurora Labs <hello@aurora.dev>", "Wei Tang <hi@that.world>", "Parity Technologies <admin@parity.io>"]
 description = "Portable Ethereum Virtual Machine implementation written in pure Rust."

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -413,35 +413,35 @@ impl Config {
 
 	/// Berlin hard fork configuration.
 	#[must_use]
-	pub fn berlin() -> Self {
+	pub const fn berlin() -> Self {
 		Self::config_with_derived_values(DerivedConfigInputs::berlin())
 	}
 
 	/// london hard fork configuration.
 	#[must_use]
-	pub fn london() -> Self {
+	pub const fn london() -> Self {
 		Self::config_with_derived_values(DerivedConfigInputs::london())
 	}
 
 	/// The Merge (Paris) hard fork configuration.
 	#[must_use]
-	pub fn merge() -> Self {
+	pub const fn merge() -> Self {
 		Self::config_with_derived_values(DerivedConfigInputs::merge())
 	}
 
 	/// Shanghai hard fork configuration.
 	#[must_use]
-	pub fn shanghai() -> Self {
+	pub const fn shanghai() -> Self {
 		Self::config_with_derived_values(DerivedConfigInputs::shanghai())
 	}
 
 	/// Cancun hard fork configuration.
 	#[must_use]
-	pub fn cancun() -> Self {
+	pub const fn cancun() -> Self {
 		Self::config_with_derived_values(DerivedConfigInputs::cancun())
 	}
 
-	fn config_with_derived_values(inputs: DerivedConfigInputs) -> Self {
+	const fn config_with_derived_values(inputs: DerivedConfigInputs) -> Self {
 		let DerivedConfigInputs {
 			gas_storage_read_warm,
 			gas_sload_cold,
@@ -463,10 +463,11 @@ impl Config {
 		let gas_sload = gas_storage_read_warm;
 		let gas_sstore_reset = 5000 - gas_sload_cold;
 
+		// In that particular case allow unsigned casting to signed as it can't be more than `i64::MAX`.
+		#[allow(clippy::as_conversions, clippy::cast_possible_wrap)]
 		// See https://eips.ethereum.org/EIPS/eip-3529
 		let refund_sstore_clears = if decrease_clears_refund {
-			// Avoid unsigned casting to signed as it may overflow
-			i64::try_from(gas_sstore_reset + gas_access_list_storage_key).unwrap_or(i64::MAX)
+			(gas_sstore_reset + gas_access_list_storage_key) as i64
 		} else {
 			15000
 		};


### PR DESCRIPTION
## Description

➡️  Fixed config hard fork function as `const fn`

### Motivation

For now, keeping functions as `const` with `from` or `try_form` transformation is impossible.

In that particular case, `unsigned -> signed` casting is safe for `EVM hard fork config functions`.

⚠️  `cons fn ` config functions is pretty helpful as EVM initialization.