### PR TITLE
Fix: Refactore EOFMAGIC check creation

### DIFF
--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -168,6 +168,8 @@ pub enum ExitError {
 	/// `usize` casting overflow
 	#[cfg_attr(feature = "with-codec", codec(index = 15))]
 	UsizeOverflow,
+	#[cfg_attr(feature = "with-codec", codec(index = 15))]
+	CreateContractStartingWithEF,
 }
 
 impl From<ExitError> for ExitReason {


### PR DESCRIPTION
## Description

Related to issue #58.

◀️ Refactored contract creation code check from `Opcode(0xEF)` to just integer
➡️ Added EVM error `CreateContractStartingWithEF`

⚠️ Opcode removal is in PR #57