### PR TITLE
Chore: Update eth-tests to v14.1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  ETHTESTS_VERSION: v14.0
+  ETHTESTS_VERSION: v14.1
 
 jobs:
   lint:


### PR DESCRIPTION
## Description

⏫  Updated https://github.com/ethereum/tests to `v14.1`