### PR TITLE
Chore: update to Rust 1.81.0

### DIFF
--- a/evm-tests/ethjson/src/bytes.rs
+++ b/evm-tests/ethjson/src/bytes.rs
@@ -29,7 +29,7 @@ pub struct Bytes(Vec<u8>);
 
 impl Bytes {
 	/// Creates bytes struct.
-	pub fn new(v: Vec<u8>) -> Self {
+	pub const fn new(v: Vec<u8>) -> Self {
 		Self(v)
 	}
 }

--- a/evm-tests/ethjson/src/spec/spec.rs
+++ b/evm-tests/ethjson/src/spec/spec.rs
@@ -81,12 +81,15 @@ impl ForkSpec {
 				| Self::HomesteadToEIP150At5
 				| Self::ByzantiumToConstantinopleFixAt5
 				| Self::ConstantinopleFixToIstanbulAt5
-				| Self::EIP150 | Self::EIP158
-				| Self::Frontier | Self::Homestead
+				| Self::EIP150
+				| Self::EIP158
+				| Self::Frontier
+				| Self::Homestead
 				| Self::Byzantium
 				| Self::Constantinople
 				| Self::ConstantinopleFix
-				| Self::Istanbul | Self::Berlin
+				| Self::Istanbul
+				| Self::Berlin
 		)
 	}
 }

--- a/evm-tests/ethjson/src/test_helpers/skip.rs
+++ b/evm-tests/ethjson/src/test_helpers/skip.rs
@@ -63,7 +63,7 @@ pub struct StateSkipSubStates {
 
 impl SkipTests {
 	/// Empty skip states.
-	pub fn empty() -> Self {
+	pub const fn empty() -> Self {
 		Self {
 			block: Vec::new(),
 			state: Vec::new(),

--- a/evm-tests/jsontests/src/state.rs
+++ b/evm-tests/jsontests/src/state.rs
@@ -1107,10 +1107,12 @@ fn test_run(
 					spec,
 					ForkSpec::EIP150
 						| ForkSpec::EIP158 | ForkSpec::Frontier
-						| ForkSpec::Homestead | ForkSpec::Byzantium
+						| ForkSpec::Homestead
+						| ForkSpec::Byzantium
 						| ForkSpec::Constantinople
 						| ForkSpec::ConstantinopleFix
-						| ForkSpec::Istanbul | ForkSpec::Berlin
+						| ForkSpec::Istanbul
+						| ForkSpec::Berlin
 				) && TxType::from_txbytes(&state.txbytes) != TxType::Legacy
 					&& state.expect_exception.as_deref() == Some("TR_TypeNotSupported");
 			if expect_tx_type_not_supported {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.80.0"
+channel = "1.81.0"
 profile = "minimal"
 components = ["rustfmt", "clippy"]

--- a/src/backend/memory.rs
+++ b/src/backend/memory.rs
@@ -73,7 +73,10 @@ pub struct MemoryBackend<'vicinity> {
 impl<'vicinity> MemoryBackend<'vicinity> {
 	/// Create a new memory backend.
 	#[must_use]
-	pub fn new(vicinity: &'vicinity MemoryVicinity, state: BTreeMap<H160, MemoryAccount>) -> Self {
+	pub const fn new(
+		vicinity: &'vicinity MemoryVicinity,
+		state: BTreeMap<H160, MemoryAccount>,
+	) -> Self {
 		Self {
 			vicinity,
 			state,


### PR DESCRIPTION
## Description

- Updated toolchain to `Rust 1.81.0`
- Fixed clippy and formating according to new requirements