### PR TITLE
Feat: optimizations with `smallvec`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ ethereum = { version = "0.15", default-features = false }
 log = { version = "0.4", default-features = false }
 primitive-types = { workspace = true, features = ["rlp"] }
 rlp = { version = "0.5", default-features = false }
-smallvec = "1.13    "
+smallvec = "1.13"
 
 # Optional dependencies
 environmental = { version = "1.1.2", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ ethereum = { version = "0.15", default-features = false }
 log = { version = "0.4", default-features = false }
 primitive-types = { workspace = true, features = ["rlp"] }
 rlp = { version = "0.5", default-features = false }
+smallvec = "1.13    "
 
 # Optional dependencies
 environmental = { version = "1.1.2", default-features = false, optional = true }

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -1642,7 +1642,7 @@ impl<'inner, 'config, 'precompiles, S: StackState<'config>, P: PrecompileSet> Pr
 				// change to the precompile API. But this means a custom precompile could still
 				// potentially cause a stack overflow if you're not careful.
 				let mut call_stack: SmallVec<[TaggedRuntime; DEFAULT_CALL_STACK_CAPACITY]> =
-					smallvec![rt.0];
+					smallvec!(rt.0);
 				let (reason, _, return_data) =
 					self.executor.execute_with_call_stack(&mut call_stack);
 				emit_exit!(reason, return_data)

--- a/src/executor/stack/executor.rs
+++ b/src/executor/stack/executor.rs
@@ -16,6 +16,7 @@ use evm_core::{ExitFatal, InterpreterHandler, Machine, Trap};
 use evm_runtime::Resolve;
 use primitive_types::{H160, H256, U256};
 use sha3::{Digest, Keccak256};
+use smallvec::{smallvec, SmallVec};
 
 macro_rules! emit_exit {
 	($reason:expr) => {{
@@ -377,11 +378,11 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 
 	/// Execute the runtime until it returns.
 	pub fn execute(&mut self, runtime: &mut Runtime) -> ExitReason {
-		let mut call_stack = Vec::with_capacity(DEFAULT_CALL_STACK_CAPACITY);
-		call_stack.push(TaggedRuntime {
-			kind: RuntimeKind::Execute,
-			inner: MaybeBorrowed::Borrowed(runtime),
-		});
+		let mut call_stack: SmallVec<[TaggedRuntime; DEFAULT_CALL_STACK_CAPACITY]> =
+			smallvec!(TaggedRuntime {
+				kind: RuntimeKind::Execute,
+				inner: MaybeBorrowed::Borrowed(runtime),
+			});
 		let (reason, _, _) = self.execute_with_call_stack(&mut call_stack);
 		reason
 	}
@@ -389,7 +390,7 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 	/// Execute using Runtimes on the `call_stack` until it returns.
 	fn execute_with_call_stack(
 		&mut self,
-		call_stack: &mut Vec<TaggedRuntime<'_>>,
+		call_stack: &mut SmallVec<[TaggedRuntime<'_>; DEFAULT_CALL_STACK_CAPACITY]>,
 	) -> (ExitReason, Option<H160>, Vec<u8>) {
 		// This `interrupt_runtime` is used to pass the runtime obtained from the
 		// `Capture::Trap` branch in the match below back to the top of the call stack.
@@ -544,8 +545,8 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 		) {
 			Capture::Exit((s, _, v)) => emit_exit!(s, v),
 			Capture::Trap(rt) => {
-				let mut cs = Vec::with_capacity(DEFAULT_CALL_STACK_CAPACITY);
-				cs.push(rt.0);
+				let mut cs: SmallVec<[TaggedRuntime<'_>; DEFAULT_CALL_STACK_CAPACITY]> =
+					smallvec!(rt.0);
 				let (s, _, v) = self.execute_with_call_stack(&mut cs);
 				emit_exit!(s, v)
 			}
@@ -590,8 +591,8 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 		) {
 			Capture::Exit((s, _, v)) => emit_exit!(s, v),
 			Capture::Trap(rt) => {
-				let mut cs = Vec::with_capacity(DEFAULT_CALL_STACK_CAPACITY);
-				cs.push(rt.0);
+				let mut cs: SmallVec<[TaggedRuntime<'_>; DEFAULT_CALL_STACK_CAPACITY]> =
+					smallvec!(rt.0);
 				let (s, _, v) = self.execute_with_call_stack(&mut cs);
 				emit_exit!(s, v)
 			}
@@ -651,8 +652,8 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 		) {
 			Capture::Exit((s, _, v)) => emit_exit!(s, v),
 			Capture::Trap(rt) => {
-				let mut cs = Vec::with_capacity(DEFAULT_CALL_STACK_CAPACITY);
-				cs.push(rt.0);
+				let mut cs: SmallVec<[TaggedRuntime<'_>; DEFAULT_CALL_STACK_CAPACITY]> =
+					smallvec!(rt.0);
 				let (s, _, v) = self.execute_with_call_stack(&mut cs);
 				emit_exit!(s, v)
 			}
@@ -722,8 +723,8 @@ impl<'config, 'precompiles, S: StackState<'config>, P: PrecompileSet>
 		) {
 			Capture::Exit((s, v)) => emit_exit!(s, v),
 			Capture::Trap(rt) => {
-				let mut cs = Vec::with_capacity(DEFAULT_CALL_STACK_CAPACITY);
-				cs.push(rt.0);
+				let mut cs: SmallVec<[TaggedRuntime<'_>; DEFAULT_CALL_STACK_CAPACITY]> =
+					smallvec!(rt.0);
 				let (s, _, v) = self.execute_with_call_stack(&mut cs);
 				emit_exit!(s, v)
 			}
@@ -1640,8 +1641,8 @@ impl<'inner, 'config, 'precompiles, S: StackState<'config>, P: PrecompileSet> Pr
 				// not allow it. For now we'll make a recursive call instead of making a breaking
 				// change to the precompile API. But this means a custom precompile could still
 				// potentially cause a stack overflow if you're not careful.
-				let mut call_stack = Vec::with_capacity(DEFAULT_CALL_STACK_CAPACITY);
-				call_stack.push(rt.0);
+				let mut call_stack: SmallVec<[TaggedRuntime; DEFAULT_CALL_STACK_CAPACITY]> =
+					smallvec![rt.0];
 				let (reason, _, return_data) =
 					self.executor.execute_with_call_stack(&mut call_stack);
 				emit_exit!(reason, return_data)


### PR DESCRIPTION
## Description

Added optimizations with `smallvec` crate. The intention is to reduce memory allocation when it possible.

One of the most significant problems for memory allocation and re-allocation is unknown size of data. To mitigate it, we can allocate on the stack for arrays, when size is known. And reallocate memory on the heap for program and algorithm needs. `smallvec` solves it good enough.

### Simulation results

It was tested through `aurora-engine` tests. It shows insignificant NEAR gas consumption improvement.

#### ⚠️ Notes

As NEAR gas consumption improved insignificantly, I don't mind if there are some arguments against this solution.
