### PR TITLE
Feat: update toolchain and refactore dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,19 +9,19 @@ keywords.workspace = true
 edition.workspace = true
 
 [workspace.dependencies]
-evm = { version = "0.46.1", path = "." }
-evm-core = { version = "0.46.1", path = "core", default-features = false }
-evm-gasometer = { version = "0.46.1", path = "gasometer", default-features = false }
-evm-runtime = { version = "0.46.1", path = "runtime", default-features = false }
-primitive-types = { version = "0.12", default-features = false }
+evm = { version = "0.46.2", path = "." }
+evm-core = { version = "0.46.2", path = "core", default-features = false }
+evm-gasometer = { version = "0.46.2", path = "gasometer", default-features = false }
+evm-runtime = { version = "0.46.2", path = "runtime", default-features = false }
+primitive-types = { version = "0.13", default-features = false }
 auto_impl = "1.0"
 sha3 = { version = "0.10", default-features = false }
 
 [dependencies]
-ethereum = { version = "0.15", default-features = false }
+# ethereum = { version = "0.15", default-features = false }
 log = { version = "0.4", default-features = false }
 primitive-types = { workspace = true, features = ["rlp"] }
-rlp = { version = "0.5", default-features = false }
+rlp = { version = "0.6", default-features = false, features = ["derive"] }
 smallvec = "1.13"
 
 # Optional dependencies
@@ -47,7 +47,6 @@ harness = false
 [features]
 default = ["std", "force-debug"]
 std = [
-    "ethereum/std",
     "log/std",
     "primitive-types/std",
     "rlp/std",
@@ -65,14 +64,12 @@ with-codec = [
     "scale-info",
     "primitive-types/codec",
     "primitive-types/scale-info",
-    "ethereum/with-codec",
     "evm-core/with-codec",
 ]
 with-serde = [
     "serde",
     "primitive-types/impl-serde",
     "evm-core/with-serde",
-    "ethereum/with-serde",
 ]
 tracing = [
     "environmental",
@@ -88,7 +85,7 @@ create-fixed = []
 print-debug = ["evm-gasometer/print-debug"]
 
 [workspace.package]
-version = "0.46.1"
+version = "0.46.2"
 license = "Apache-2.0"
 authors = ["Aurora Labs <hello@aurora.dev>", "Wei Tang <hi@that.world>", "Parity Technologies <admin@parity.io>"]
 description = "Portable Ethereum Virtual Machine implementation written in pure Rust."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ auto_impl = "1.0"
 sha3 = { version = "0.10", default-features = false }
 
 [dependencies]
-# ethereum = { version = "0.15", default-features = false }
 log = { version = "0.4", default-features = false }
 primitive-types = { workspace = true, features = ["rlp"] }
 rlp = { version = "0.6", default-features = false, features = ["derive"] }

--- a/core/src/eval/macros.rs
+++ b/core/src/eval/macros.rs
@@ -21,11 +21,7 @@ macro_rules! pop_h256 {
 	( $machine:expr, $( $x:ident ),* ) => (
 		$(
 			let $x = match $machine.stack.pop() {
-				Ok(value) => {
-					let mut res = H256([0; 32]);
-					value.to_big_endian(&mut res[..]);
-					res
-				},
+				Ok(value) => H256(value.to_big_endian()),
 				Err(e) => return Control::Exit(e.into()),
 			};
 		)*

--- a/core/src/stack.rs
+++ b/core/src/stack.rs
@@ -62,11 +62,7 @@ impl Stack {
 	/// Return `ExitError`
 	#[inline]
 	pub fn pop_h256(&mut self) -> Result<H256, ExitError> {
-		self.pop().map(|it| {
-			let mut res = H256([0; 32]);
-			it.to_big_endian(&mut res.0);
-			res
-		})
+		self.pop().map(|it| H256(it.to_big_endian()))
 	}
 
 	/// Push a new value into the stack. If it will exceed the stack limit,
@@ -106,11 +102,7 @@ impl Stack {
 	/// # Errors
 	/// Return `ExitError`
 	pub fn peek_h256(&self, no_from_top: usize) -> Result<H256, ExitError> {
-		self.peek(no_from_top).map(|it| {
-			let mut res = H256([0; 32]);
-			it.to_big_endian(&mut res.0);
-			res
-		})
+		self.peek(no_from_top).map(|it| H256(it.to_big_endian()))
 	}
 
 	/// Peek a value at given index for the stack as usize.

--- a/evm-tests/EIP-152/src/lib.rs
+++ b/evm-tests/EIP-152/src/lib.rs
@@ -14,6 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Open Ethereum.  If not, see <http://www.gnu.org/licenses/>.
 
+#![allow(clippy::too_long_first_doc_paragraph)]
+
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 pub mod avx2;
 pub mod portable;

--- a/evm-tests/ethcore-builtin/Cargo.toml
+++ b/evm-tests/ethcore-builtin/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 bn = { git = "https://github.com/paritytech/bn", rev = "b048fe1", default-features = false }
 byteorder = "1.3.2"
 eip-152 = { path = "../EIP-152" }
-ethereum-types = "0.14"
+ethereum-types = "0.15"
 ethjson = { path = "../ethjson" }
 keccak-hash = "0.10"
 log = "0.4"

--- a/evm-tests/ethcore-builtin/src/lib.rs
+++ b/evm-tests/ethcore-builtin/src/lib.rs
@@ -1159,8 +1159,7 @@ impl Bn128Pairing {
 			}
 		};
 
-		let mut buf = [0u8; 32];
-		ret_val.to_big_endian(&mut buf);
+		let buf = ret_val.to_big_endian();
 		output.write(0, &buf);
 
 		Ok(())

--- a/evm-tests/ethjson/Cargo.toml
+++ b/evm-tests/ethjson/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 
 [dependencies]
-ethereum-types = "0.14"
+ethereum-types = "0.15"
 rustc-hex = "2.1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/evm-tests/ethjson/src/lib.rs
+++ b/evm-tests/ethjson/src/lib.rs
@@ -17,6 +17,7 @@
 //! JSON deserialization library
 
 #![warn(missing_docs)]
+#![allow(clippy::too_long_first_doc_paragraph)]
 
 pub mod bytes;
 pub mod hash;

--- a/evm-tests/jsontests/Cargo.toml
+++ b/evm-tests/jsontests/Cargo.toml
@@ -11,7 +11,7 @@ edition.workspace = true
 [dependencies]
 evm.workspace = true
 ethereum = "0.15.0"
-primitive-types = "0.12"
+primitive-types = "0.13"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 hex = "0.4"
@@ -19,11 +19,11 @@ clap = { version = "4.5", features = ["cargo"] }
 ethjson = { path = "../ethjson", features = ["test-helpers"] }
 libsecp256k1 = "0.7"
 ethcore-builtin = { path = "../ethcore-builtin" }
-rlp = "0.5"
+rlp = "0.6"
 sha3 = "0.10"
 parity-bytes = "0.1"
 env_logger = "0.11"
-lazy_static = "1.4.0"
+lazy_static = "1.5"
 
 [features]
 enable-slow-tests = []

--- a/evm-tests/jsontests/src/state.rs
+++ b/evm-tests/jsontests/src/state.rs
@@ -1288,8 +1288,6 @@ fn test_run(
 					);
 					for (addr, acc) in backend.state().clone() {
 						// Decode balance
-						let mut write_buf = [0u8; 32];
-						acc.balance.to_big_endian(&mut write_buf[..]);
 						let balance = acc.balance.to_string();
 
 						println!(

--- a/evm-tests/jsontests/src/vm.rs
+++ b/evm-tests/jsontests/src/vm.rs
@@ -24,9 +24,7 @@ impl Test {
 			// (0x44), and so for older forks of Ethereum, the threshold value of 2^64 is used to
 			// distinguish between the two: if it's below, the value corresponds to the DIFFICULTY
 			// opcode, otherwise to the PREVRANDAO opcode.
-			let mut buf = [0u8; 32];
-			r.0.to_big_endian(&mut buf);
-			H256(buf)
+			H256(r.0.to_big_endian())
 		});
 
 		MemoryVicinity {

--- a/runtime/src/eval/macros.rs
+++ b/runtime/src/eval/macros.rs
@@ -11,11 +11,7 @@ macro_rules! pop_h256 {
 	( $machine:expr, $( $x:ident ),* ) => (
 		$(
 			let $x = match $machine.machine.stack_mut().pop() {
-				Ok(value) => {
-					let mut res = H256([0; 32]);
-					value.to_big_endian(&mut res[..]);
-					res
-				},
+				Ok(value) => H256(value.to_big_endian()),
 				Err(e) => return Control::Exit(e.into()),
 			};
 		)*

--- a/runtime/src/eval/system.rs
+++ b/runtime/src/eval/system.rs
@@ -73,16 +73,14 @@ pub fn caller<H: Handler>(runtime: &mut Runtime) -> Control<H> {
 }
 
 pub fn callvalue<H: Handler>(runtime: &mut Runtime) -> Control<H> {
-	let mut ret = H256::default();
-	runtime.context.apparent_value.to_big_endian(&mut ret[..]);
+	let ret = H256(runtime.context.apparent_value.to_big_endian());
 	push_h256!(runtime, ret);
 
 	Control::Continue
 }
 
 pub fn gasprice<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
-	let mut ret = H256::default();
-	handler.gas_price().to_big_endian(&mut ret[..]);
+	let ret = H256(handler.gas_price().to_big_endian());
 	push_h256!(runtime, ret);
 
 	Control::Continue
@@ -294,11 +292,7 @@ pub fn sstore<H: Handler>(runtime: &mut Runtime, handler: &mut H) -> Control<H> 
 pub fn tload<H: Handler>(runtime: &mut Runtime, handler: &mut H) -> Control<H> {
 	// Peek index from the top of the stack
 	let index = match runtime.machine.stack().peek(0) {
-		Ok(value) => {
-			let mut h = H256::default();
-			value.to_big_endian(&mut h[..]);
-			h
-		}
+		Ok(value) => H256(value.to_big_endian()),
 		Err(e) => return Control::Exit(e.into()),
 	};
 	// Load value from transient storage

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.82.0"
 profile = "minimal"
 components = ["rustfmt", "clippy"]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -22,7 +22,17 @@ pub struct Basic {
 	pub nonce: U256,
 }
 
-pub use ethereum::Log;
+#[derive(Clone, Debug, PartialEq, Eq, Default, rlp::RlpEncodable, rlp::RlpDecodable)]
+#[cfg_attr(
+	feature = "with-codec",
+	derive(scale_codec::Encode, scale_codec::Decode, scale_info::TypeInfo)
+)]
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Log {
+	pub address: H160,
+	pub topics: Vec<H256>,
+	pub data: Vec<u8>,
+}
 
 /// Apply state operation.
 #[derive(Clone, Debug)]

--- a/src/executor/stack/mod.rs
+++ b/src/executor/stack/mod.rs
@@ -14,4 +14,3 @@ pub use self::memory::{MemoryStackAccount, MemoryStackState, MemoryStackSubstate
 pub use self::precompile::{
 	PrecompileFailure, PrecompileFn, PrecompileHandle, PrecompileOutput, PrecompileSet,
 };
-pub use ethereum::Log;

--- a/src/maybe_borrowed.rs
+++ b/src/maybe_borrowed.rs
@@ -1,6 +1,7 @@
 //! A module containing the `MaybeBorrowed` enum. See its documentation for details.
 
 /// Similar to `Cow` from the standard library, but without requiring `T: Clone`.
+///
 /// Instead of "copy on write", this data structure represents a type that can create
 /// `&mut T`, either because it is `&mut T`, or because it is an owned `T`.
 /// This is also distinct from the `BorrowMut` trait in the standard library because


### PR DESCRIPTION
## Description

⛓️ 🛋️  Updated:
➡️ Rust  toolchain `1.82.0` 
➡️ Refactored dependencies
- new version of `primitive-types`
- new version of `rlp`
- remover `ethereum` dependency as outdated and incompatible with the new version of `primitive-types`. Created new type `Log`.