### PR TITLE
chore: add catalog entities

### DIFF
--- a/.catalog-info.yaml
+++ b/.catalog-info.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Location
+metadata:
+    name: sputnikvm-public
+    description: SputnikVM repository
+spec:
+    targets:
+        - ./core/.catalog-info.yaml
+        - ./runtime/.catalog-info.yaml
+        - ./gasometer/.catalog-info.yaml
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+    name: sputnikvm-evm
+    title: SputnikVM evm
+    description: Main library that re-exports most things
+    tags:
+        - ethereum
+    links: []
+    annotations:
+        aurora.dev/security-tier: "1"
+spec:
+    owner: engine-team
+    type: library
+    lifecycle: production

--- a/core/.catalog-info.yaml
+++ b/core/.catalog-info.yaml
@@ -1,0 +1,16 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+    name: sputnikvm-core
+    title: SputnikVM core
+    description: Core library defining the basic execution rules
+    tags:
+        - ethereum
+    links: []
+    annotations:
+        aurora.dev/security-tier: "1"
+spec:
+    owner: engine-team
+    type: library
+    lifecycle: production
+    subcomponentOf: sputnikvm-evm

--- a/gasometer/.catalog-info.yaml
+++ b/gasometer/.catalog-info.yaml
@@ -1,0 +1,16 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+    name: sputnikvm-gasometer
+    title: SputnikVM gasometer
+    description: Integration of Ethereum gas rules
+    tags:
+        - ethereum
+    links: []
+    annotations:
+        aurora.dev/security-tier: "1"
+spec:
+    owner: engine-team
+    type: library
+    lifecycle: production
+    subcomponentOf: sputnikvm-evm

--- a/runtime/.catalog-info.yaml
+++ b/runtime/.catalog-info.yaml
@@ -1,0 +1,16 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+    name: sputnikvm-runtime
+    title: SputnikVM runtime
+    description: Runtime defining interface for block, transaction, and storage
+    tags:
+        - ethereum
+    links: []
+    annotations:
+        aurora.dev/security-tier: "1"
+spec:
+    owner: engine-team
+    type: library
+    lifecycle: production
+    subcomponentOf: sputnikvm-evm


### PR DESCRIPTION
## Description
PR takes care of adding [catalog descriptor files](https://backstage.io/docs/features/software-catalog/descriptor-format) that represent `sputnikvm` as a library for our software catalog.