### PR TITLE
Feat: Add state tests dump for jsottests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,6 +25,8 @@ jobs:
         run: cargo clippy --no-default-features -- -D clippy::all -D clippy::nursery
       - name: Clippy with features
         run: cargo clippy --features tracing,create-fixed -- -D clippy::all -D clippy::nursery
+      - name: Clippy with features for evm-jsontests
+        run: cargo clippy -p evm-jsontests --features dump-state -- -D clippy::all -D clippy::nursery
 
   build:
     runs-on: ubuntu-latest

--- a/evm-tests/ethcore-builtin/src/lib.rs
+++ b/evm-tests/ethcore-builtin/src/lib.rs
@@ -986,6 +986,11 @@ impl Implementation for Bls12MapFpToG1 {
 impl Implementation for Bls12MapFp2ToG2 {
 	fn execute(&self, input: &[u8], output: &mut BytesRef) -> Result<(), &'static str> {
 		let out = bls::map_fp2_to_g2::map_fp2_to_g2(input)?;
+		println!(
+			"{{ \"input\": {:?}, \"output\": {:?} }},",
+			hex::encode(&input),
+			hex::encode(&out)
+		);
 		output.write(0, out.as_slice());
 		Ok(())
 	}

--- a/evm-tests/jsontests/Cargo.toml
+++ b/evm-tests/jsontests/Cargo.toml
@@ -22,9 +22,9 @@ ethcore-builtin = { path = "../ethcore-builtin" }
 rlp = "0.6"
 sha3 = "0.10"
 parity-bytes = "0.1"
-env_logger = "0.11"
 hex-literal = "0.4"
 
 [features]
 enable-slow-tests = []
 print-debug = ["evm/print-debug"]
+dump-state = ["evm/with-serde"]

--- a/evm-tests/jsontests/src/state.rs
+++ b/evm-tests/jsontests/src/state.rs
@@ -117,7 +117,7 @@ impl StateTestsDumper for StateTestsDump {
 			.duration_since(UNIX_EPOCH)
 			.unwrap()
 			.as_micros();
-		let path = format!("{spec:?}_BLS12-382_g1_add_{now}.json");
+		let path = format!("{spec:?}_BLS12-382_{now}.json");
 		let json = serde_json::to_string(&self).unwrap();
 		std::fs::write(path, json).unwrap();
 	}


### PR DESCRIPTION
## Description

Created a tool for dumping test cases from `jsontests`. It dump relevant EVM state to reproduce it in `aurora-engine-tests`.

➡️ Added feature flag for dumping tool.
➡️ Related to: aurora-is-near/aurora-engine/pull/990