### PR TITLE
Fix EIP-7623 gas floor charging

### DIFF
--- a/evm/src/gasometer/mod.rs
+++ b/evm/src/gasometer/mod.rs
@@ -533,7 +533,13 @@ impl<'config> Gasometer<'config> {
             self.inner_mut()?.floor_gas = floor_gas;
         }
 
-        self.inner_mut()?.used_gas += gas_cost;
+        let effective_cost = if self.config.has_floor_gas {
+            core::cmp::max(gas_cost, floor_gas)
+        } else {
+            gas_cost
+        };
+
+        self.inner_mut()?.used_gas += effective_cost;
         Ok(())
     }
 


### PR DESCRIPTION
Previously, the gasometer computed both the standard intrinsic gas `gas_cost` and the calldata floor gas `floor_gas`, but only `gas_cost` was added to `used_gas`. As a result, a transaction could satisfy the floor check and still be charged
  only the lower intrinsic gas amount. The fix changes `gasometer::mod::record_transaction()` to charge `max(gas_cost, floor_gas)` whenever `has_floor_gas` is enabled. 

This is important because `EIP-7623` is meant to enforce a minimum calldata cost for transactions with heavy calldata usage; validating the floor without actually charging it undermines the purpose of the EIP and leads to undercharging and inconsistent gas accounting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated gas metering to apply a configurable minimum floor when calculating transaction charges. Gas costs now reflect the maximum of the actual cost and the configured floor value.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aurora-is-near/aurora-evm/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->