### PR TITLE
Feat: Update rust to 1.97.0 and clippy rules

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,13 +19,13 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Clippy
-        run: cargo clippy --workspace --all-targets -- -D clippy::all -D clippy::nursery
+        run: cargo clippy --workspace --all-targets
       - name: Clippy no_std
-        run: cargo clippy --no-default-features -- -D clippy::all -D clippy::nursery
+        run: cargo clippy --no-default-features
       - name: Clippy with features
-        run: cargo clippy --features tracing,create-fixed,with-serde -- -D clippy::all -D clippy::nursery
+        run: cargo clippy --features tracing,create-fixed,with-serde
       - name: Clippy with features for aurora-evm-jsontests
-        run: cargo clippy -p aurora-evm-jsontests --features dump-state -- -D clippy::all -D clippy::nursery
+        run: cargo clippy -p aurora-evm-jsontests --features dump-state
 
   build:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,16 @@ repository = "https://github.com/aurora-is-near/aurora-evm"
 license = "MIT"
 readme = "README.md"
 
+[workspace.lints.rust]
+warnings = "deny"
+
+[workspace.lints.clippy]
+all = { level = "deny", priority = -1 }
+pedantic = { level = "deny", priority = -1 }
+nursery = { level = "deny", priority = -1 }
+as_conversions = "deny"
+module_name_repetitions = "allow"
+
 [workspace.dependencies]
 aurora-evm = { path = "evm" }
 auto_impl = "1.0"

--- a/evm-tests/Cargo.toml
+++ b/evm-tests/Cargo.toml
@@ -9,10 +9,8 @@ keywords.workspace = true
 edition.workspace = true
 publish = false
 
-[lints.clippy]
-all = { level = "deny", priority = -1 }
-pedantic = { level = "deny", priority = -1 }
-nursery = { level = "deny", priority = -1 }
+[lints]
+workspace = true
 
 [dependencies]
 aurora-engine-precompiles = "2.1.0"

--- a/evm-tests/src/execution_results.rs
+++ b/evm-tests/src/execution_results.rs
@@ -180,7 +180,7 @@ impl TestExecutionResult {
 
     pub fn print_bench(&self) {
         let mut items = self.bench.clone();
-        items.sort_unstable_by(|a, b| b.elapsed.cmp(&a.elapsed));
+        items.sort_unstable_by_key(|b| core::cmp::Reverse(b.elapsed));
 
         if items.is_empty() {
             return;
@@ -213,7 +213,7 @@ impl TestExecutionResult {
             let e_pad = format!("{e:w_elapsed$}");
             let s_pad = format!("{s:w_spec$}");
             let n_pad = format!("{n:w_name$}");
-            println!("{bold_on}{e_pad}{reset}  {gray_on}{s_pad}{reset}  {n_pad}",);
+            println!("{bold_on}{e_pad}{reset}  {gray_on}{s_pad}{reset}  {n_pad}");
         }
     }
 }

--- a/evm-tests/src/main.rs
+++ b/evm-tests/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::too_long_first_doc_paragraph, clippy::missing_panics_doc)]
+#![allow(clippy::unnecessary_debug_formatting, clippy::as_conversions)]
 
 use crate::config::{TestConfig, VerboseOutput};
 use crate::execution_results::TestExecutionResult;

--- a/evm-tests/src/types/blob.rs
+++ b/evm-tests/src/types/blob.rs
@@ -168,6 +168,9 @@ pub fn calc_max_data_fee(config: &Config, tx: &Transaction) -> Option<U256> {
 /// Calculates the [EIP-4844] `data_fee` of the transaction.
 ///
 /// [EIP-4844]: https://eips.ethereum.org/EIPS/eip-4844
+///
+/// ## Panics
+/// When parsing data with unexpected value
 #[inline]
 #[must_use]
 pub fn calc_data_fee(

--- a/evm-tests/src/types/mod.rs
+++ b/evm-tests/src/types/mod.rs
@@ -64,7 +64,8 @@ impl StateTestCase {
     /// Invalid transaction error status.
     ///
     /// ## Panics
-    /// When parsing data with unexpected value
+    /// Panics if a pre-London transaction has no `gas_price`, or if the transaction's secret key is
+    /// missing or fails to parse (see `get_caller_from_secret_key`).
     pub fn get_memory_vicinity(
         &self,
         spec: &Spec,

--- a/evm-tests/src/types/mod.rs
+++ b/evm-tests/src/types/mod.rs
@@ -25,6 +25,7 @@ pub use spec::Spec;
 pub use vm::VmTestCase;
 
 /// Represents a test case for the Ethereum state transitions.
+///
 /// It includes the environment setup, pre-state, transaction details,
 /// expected post-state results for different forks, configuration, and metadata.
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Clone, Deserialize)]
@@ -59,8 +60,11 @@ pub struct StateTestCase {
 impl StateTestCase {
     /// Get the memory vicinity for the transaction, which includesState test data.
     ///
-    /// # Errors
+    /// ## Errors
     /// Invalid transaction error status.
+    ///
+    /// ## Panics
+    /// When parsing data with unexpected value
     pub fn get_memory_vicinity(
         &self,
         spec: &Spec,

--- a/evm-tests/src/types/transaction.rs
+++ b/evm-tests/src/types/transaction.rs
@@ -86,6 +86,9 @@ impl Transaction {
     }
 
     /// Get `access_list` from with state data
+    ///
+    /// ## Panics
+    /// When parsing data with unexpected value
     #[must_use]
     pub fn get_access_list(&self, state: &PostState) -> Vec<(H160, Vec<H256>)> {
         if state.indexes.data < self.access_lists.len() {
@@ -145,6 +148,9 @@ impl Transaction {
     ///
     /// # Errors
     /// Returns `InvalidTxReason` if validation fails.
+    ///
+    /// ## Panics
+    /// When parsing data with unexpected value
     #[allow(clippy::too_many_lines, clippy::too_many_arguments)]
     pub fn validate(
         &self,
@@ -378,6 +384,9 @@ impl TxType {
     /// Whether this is a legacy, access list, dynamic fee, etc. transaction
     /// Taken from geth's core/types/transaction.go/UnmarshalBinary, but we only detect the transaction
     /// type rather than unmarshal the entire payload.
+    ///
+    /// ## Panics
+    /// When parsing data with unexpected tx data.
     #[must_use]
     pub const fn from_tx_bytes(tx_bytes: &[u8]) -> Self {
         match tx_bytes[0] {

--- a/evm-tests/src/types/transaction.rs
+++ b/evm-tests/src/types/transaction.rs
@@ -85,24 +85,17 @@ impl Transaction {
         self.value[state.indexes.value]
     }
 
-    /// Get `access_list` from with state data
-    ///
-    /// ## Panics
-    /// When parsing data with unexpected value
+    /// Get `access_list` for the current state data index (empty if absent or out of range).
     #[must_use]
     pub fn get_access_list(&self, state: &PostState) -> Vec<(H160, Vec<H256>)> {
-        if state.indexes.data < self.access_lists.len() {
-            self.access_lists
-                .get(state.indexes.data)
-                .unwrap()
-                .clone()
-                .unwrap_or_default()
-                .into_iter()
-                .map(|a| (a.address, a.storage_keys))
-                .collect()
-        } else {
-            Vec::new()
-        }
+        self.access_lists
+            .get(state.indexes.data)
+            .cloned()
+            .flatten()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|a| (a.address, a.storage_keys))
+            .collect()
     }
 
     /// Get caller from transaction's secret key.
@@ -150,7 +143,7 @@ impl Transaction {
     /// Returns `InvalidTxReason` if validation fails.
     ///
     /// ## Panics
-    /// When parsing data with unexpected value
+    /// Panics if a blob (EIP-4844) transaction is validated without a `blob_gas_price`.
     #[allow(clippy::too_many_lines, clippy::too_many_arguments)]
     pub fn validate(
         &self,
@@ -386,7 +379,7 @@ impl TxType {
     /// type rather than unmarshal the entire payload.
     ///
     /// ## Panics
-    /// When parsing data with unexpected tx data.
+    /// Panics if `tx_bytes` is empty, or if its first byte is an unknown enveloped transaction type.
     #[must_use]
     pub const fn from_tx_bytes(tx_bytes: &[u8]) -> Self {
         match tx_bytes[0] {

--- a/evm-tests/src/types/vm.rs
+++ b/evm-tests/src/types/vm.rs
@@ -46,11 +46,19 @@ pub struct VmTestCase {
 }
 
 impl VmTestCase {
+    /// Get ouptup
+    ///
+    /// ## Panics
+    /// When parsing data with unexpected output
     #[must_use]
     pub fn get_output(&self) -> Vec<u8> {
         self.output.clone().unwrap()
     }
 
+    /// Get gas left
+    ///
+    /// ## Panics
+    /// When parsing data with unexpected gas
     #[must_use]
     pub fn get_gas_left(&self) -> u64 {
         self.gas_left.unwrap().as_u64()
@@ -61,6 +69,10 @@ impl VmTestCase {
         self.transaction.gas.as_u64()
     }
 
+    /// Validate state
+    ///
+    /// ## Panics
+    /// When parsing data with unexpected value
     #[must_use]
     pub fn validate_state(&self, state: &BTreeMap<H160, MemoryAccount>) -> bool {
         &self

--- a/evm-tests/src/types/vm.rs
+++ b/evm-tests/src/types/vm.rs
@@ -46,19 +46,19 @@ pub struct VmTestCase {
 }
 
 impl VmTestCase {
-    /// Get ouptup
+    /// Get the expected output.
     ///
     /// ## Panics
-    /// When parsing data with unexpected output
+    /// Panics if the test case has no `output` value.
     #[must_use]
     pub fn get_output(&self) -> Vec<u8> {
         self.output.clone().unwrap()
     }
 
-    /// Get gas left
+    /// Get the expected remaining gas.
     ///
     /// ## Panics
-    /// When parsing data with unexpected gas
+    /// Panics if the test case has no `gas_left` value.
     #[must_use]
     pub fn get_gas_left(&self) -> u64 {
         self.gas_left.unwrap().as_u64()

--- a/evm-tests/src/vm.rs
+++ b/evm-tests/src/vm.rs
@@ -8,6 +8,10 @@ use std::collections::BTreeMap;
 use std::io::{self, Write};
 use std::rc::Rc;
 
+/// Run test with verbose args.
+///
+/// ## Panics
+/// Flush panics if something wrong
 #[must_use]
 pub fn test(verbose_output: &VerboseOutput, name: &str, test: &VmTestCase) -> TestExecutionResult {
     let mut result = TestExecutionResult::new();
@@ -54,7 +58,7 @@ pub fn test(verbose_output: &VerboseOutput, name: &str, test: &VmTestCase) -> Te
         if !(test.post_state.is_none() && test.gas_left.is_none()) {
             failed = true;
             if verbose_output.verbose_failed {
-                print!("[Failed: not empty state and left gas for empty output: {reason:?}] ",);
+                print!("[Failed: not empty state and left gas for empty output: {reason:?}] ");
             }
         }
     } else {

--- a/evm-tests/src/vm.rs
+++ b/evm-tests/src/vm.rs
@@ -11,7 +11,7 @@ use std::rc::Rc;
 /// Run test with verbose args.
 ///
 /// ## Panics
-/// Flush panics if something wrong
+/// Panics if flushing stdout fails.
 #[must_use]
 pub fn test(verbose_output: &VerboseOutput, name: &str, test: &VmTestCase) -> TestExecutionResult {
     let mut result = TestExecutionResult::new();
@@ -52,13 +52,13 @@ pub fn test(verbose_output: &VerboseOutput, name: &str, test: &VmTestCase) -> Te
         if reason.is_succeed() {
             failed = true;
             if verbose_output.verbose_failed {
-                print!("[Failed: succeed for empty output: {reason:?}] ");
+                print!("[Failed: succeed for empty output: {reason:?}]");
             }
         }
         if !(test.post_state.is_none() && test.gas_left.is_none()) {
             failed = true;
             if verbose_output.verbose_failed {
-                print!("[Failed: not empty state and left gas for empty output: {reason:?}] ");
+                print!("[Failed: not empty state and left gas for empty output: {reason:?}]");
             }
         }
     } else {
@@ -80,13 +80,13 @@ pub fn test(verbose_output: &VerboseOutput, name: &str, test: &VmTestCase) -> Te
         if !test.validate_state(backend.state()) {
             failed = true;
             if verbose_output.verbose_failed {
-                print!("[Failed: invalid state] ");
+                print!("[Failed: invalid state]");
             }
         }
         if gas != expected_post_gas {
             failed = true;
             if verbose_output.verbose_failed {
-                print!("[Failed: unexpected gas: {gas:?}] ");
+                print!("[Failed: unexpected gas: {gas:?}]");
             }
         }
     }

--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -10,6 +10,9 @@ repository.workspace = true
 license.workspace = true
 readme.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 auto_impl.workspace = true
 primitive-types = { workspace = true, features = ["rlp"] }

--- a/evm/src/backend/mod.rs
+++ b/evm/src/backend/mod.rs
@@ -102,7 +102,7 @@ pub trait Backend {
     /// [EIP-7516]: BLOBBASEFEE instruction
     fn blob_gas_price(&self) -> Option<u128>;
     /// Get `blob_hash` from `blob_versioned_hashes` by index
-    /// [EIP-4844]: BLOBHASH - https://eips.ethereum.org/EIPS/eip-4844#opcode-to-get-versioned-hashes
+    /// [EIP-4844]: BLOBHASH - <https://eips.ethereum.org/EIPS/eip-4844#opcode-to-get-versioned-hashes>
     fn get_blob_hash(&self, index: usize) -> Option<U256>;
 }
 

--- a/evm/src/executor/stack/memory.rs
+++ b/evm/src/executor/stack/memory.rs
@@ -18,7 +18,7 @@ pub struct MemoryStackAccount {
 #[derive(Clone, Debug)]
 pub struct MemoryStackSubstate<'config> {
     metadata: StackSubstateMetadata<'config>,
-    parent: Option<Box<MemoryStackSubstate<'config>>>,
+    parent: Option<Box<Self>>,
     logs: Vec<Log>,
     accounts: BTreeMap<H160, MemoryStackAccount>,
     storages: BTreeMap<(H160, H256), H256>,
@@ -593,7 +593,6 @@ impl<'config, B: Backend> StackState<'config> for MemoryStackState<'_, 'config, 
         self.substate.exit_discard()
     }
 
-    #[must_use]
     fn is_empty(&self, address: H160) -> bool {
         if let Some(account) = self.substate.known_account(address) {
             if !account.basic.balance.is_zero() || !account.basic.nonce.is_zero() {

--- a/evm/src/lib.rs
+++ b/evm/src/lib.rs
@@ -1,10 +1,6 @@
-//! Ethereum Virtual Machine implementation in Rust
+//! Aurora Ethereum Virtual Machine implementation
 
-#![deny(warnings)]
 #![forbid(unsafe_code, unused_variables)]
-#![deny(clippy::pedantic, clippy::nursery)]
-#![deny(clippy::as_conversions)]
-#![allow(clippy::module_name_repetitions)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[cfg(not(feature = "std"))]

--- a/evm/src/runtime/eval/mod.rs
+++ b/evm/src/runtime/eval/mod.rs
@@ -86,11 +86,7 @@ pub fn finish_create(
                 .push(U256::from_big_endian(&create_address[..]))?;
             Ok(())
         }
-        ExitReason::Revert(_) => {
-            runtime.machine.stack_mut().push(U256_ZERO)?;
-            Ok(())
-        }
-        ExitReason::Error(_) => {
+        ExitReason::Revert(_) | ExitReason::Error(_) => {
             runtime.machine.stack_mut().push(U256_ZERO)?;
             Ok(())
         }

--- a/evm/src/runtime/handler.rs
+++ b/evm/src/runtime/handler.rs
@@ -158,7 +158,7 @@ pub trait Handler {
     /// [EIP-7516]: BLOBBASEFEE instruction
     fn blob_base_fee(&self) -> Option<u128>;
     /// Get `blob_hash` from `blob_versioned_hashes` by index
-    /// [EIP-4844]: BLOBHASH - https://eips.ethereum.org/EIPS/eip-4844#opcode-to-get-versioned-hashes
+    /// [EIP-4844]: BLOBHASH - <https://eips.ethereum.org/EIPS/eip-4844#opcode-to-get-versioned-hashes>
     fn get_blob_hash(&self, index: usize) -> Option<U256>;
     /// Set tstorage value of address at index.
     /// [EIP-1153]: Transient storage

--- a/evm/src/runtime/mod.rs
+++ b/evm/src/runtime/mod.rs
@@ -85,7 +85,7 @@ impl Runtime {
     pub fn run<H: Handler + InterpreterHandler>(
         &mut self,
         handler: &mut H,
-    ) -> Capture<ExitReason, Resolve<H>> {
+    ) -> Capture<ExitReason, Resolve<'_, H>> {
         loop {
             let result = self.machine.step(handler, &self.context.address);
             match result {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.97.0"
 components = ["rustfmt", "clippy"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Developer Experience**
  - Updated the Rust toolchain to 1.97.0.
  - Standardized workspace linting and adjusted Clippy so warnings no longer fail CI automatically.
- **Bug Fixes**
  - EVM test benchmark output is now sorted by descending elapsed time.
  - Transaction access list retrieval now safely yields an empty list when missing or out of range.
  - Improved runtime result lifetime handling for trapped operations.
- **Refactor**
  - Simplified an internal memory stack parent type.
- **Documentation**
  - Expanded panic/error docs across EVM test helpers and refreshed EIP-4844 BLOBHASH/BLOB-related references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->